### PR TITLE
Update types file to conditionally support className for the RichTextProps 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,8 +67,7 @@ declare module "prismic-reactjs" {
 		key: string
 	) => T | null;
 
-	export interface RichTextProps {
-		Component?: React.ReactNode;
+	export interface RichTextPropsCommon {
 		elements?: {};
 		htmlSerializer?: HTMLSerializer<React.ReactNode>;
 		linkResolver?: LinkResolver;
@@ -76,6 +75,20 @@ declare module "prismic-reactjs" {
 		renderAsText?: any;
 		serializeHyperlink?: HTMLSerializer<React.ReactNode>;
 	}
+
+	export type RichTextPropsWithComponent =
+		|
+			{
+				Component?: false;
+				className?: never;
+			}
+		|
+			{
+				Component: React.ReactNode;
+				className?: string;
+			}
+
+	export type RichTextProps = RichTextPropsCommon & RichTextPropsWithComponent
 
 	export const RichText: React.FC<RichTextProps> & {
 		asText: (input: RichTextBlock[]) => string;


### PR DESCRIPTION
Hey! Hope I'm contributing the right way to the project, if not ill make any needed changes. I also noticed a failing test that was unrelated to my changes and failing on a fresh pull. Should I open a separate issue for it?

This PR should fix issue #93 cc: @angeloashmore 

When using the **<RichText />** we want to support the prop `className` only when there is a corresponding `Component` prop.

I tried a few different approaches, this was a good learning experience. Ultimately using a [discriminating-union](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#discriminating-unions) netted me the results we were looking for.

Example screenshot.

<img width="1181" alt="Screen Shot 2021-07-12 at 1 10 39 PM" src="https://user-images.githubusercontent.com/11730651/125328650-2e3f2380-e30a-11eb-910d-ffdef2ddc054.png">

Not sure if this PR will conflict with this Draft PR: https://github.com/prismicio/prismic-reactjs/pull/77. It's a year old so I did not want to branch from it.
