### PR TITLE
feat: add `resolver` prop to SliceZone for backwards compatibility with `next-slicezone`

### DIFF
--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -158,7 +158,8 @@ type SliceZoneResolverArgs<TSlice extends SliceLike = SliceLike> = {
 
 /**
  * A function that determines the rendered React component for each Slice in the
- * Slice Zone.
+ * Slice Zone. If a nullish value is returned, the component will fallback to
+ * the `components` or `defaultComponent` props to determine the rendered component.
  *
  * @deprecated Use the `components` prop instead.
  *
@@ -171,7 +172,7 @@ export type SliceZoneResolver<
 	TContext = unknown,
 > = (
 	args: SliceZoneResolverArgs<TSlice>,
-) => SliceComponentType<TSlice, TContext>;
+) => SliceComponentType<TSlice, TContext> | undefined | null;
 
 /**
  * React props for the `<SliceZone>` component.

--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -137,6 +137,43 @@ export const TODOSliceComponent = __PRODUCTION__
 	  };
 
 /**
+ * Arguments for a `<SliceZone>` `resolver` function.
+ */
+type SliceZoneResolverArgs<TSlice extends SliceLike = SliceLike> = {
+	/**
+	 * The Slice to resolve to a React component..
+	 */
+	slice: TSlice;
+
+	/**
+	 * The name of the Slice.
+	 */
+	sliceName: TSlice["slice_type"];
+
+	/**
+	 * The index of the Slice in the Slice Zone.
+	 */
+	i: number;
+};
+
+/**
+ * A function that determines the rendered React component for each Slice in the
+ * Slice Zone.
+ *
+ * @deprecated Use the `components` prop instead.
+ *
+ * @param args - Arguments for the resolver function.
+ *
+ * @returns The React component to render for a Slice.
+ */
+export type SliceZoneResolver<
+	TSlice extends SliceLike = SliceLike,
+	TContext = unknown,
+> = (
+	args: SliceZoneResolverArgs<TSlice>,
+) => SliceComponentType<TSlice, TContext>;
+
+/**
  * React props for the `<SliceZone>` component.
  *
  * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
@@ -155,6 +192,18 @@ export type SliceZoneProps<
 	 * A record mapping Slice types to React components.
 	 */
 	components?: SliceZoneComponents<TSlice, TContext>;
+
+	/**
+	 * A function that determines the rendered React component for each Slice in
+	 * the Slice Zone.
+	 *
+	 * @deprecated Use the `components` prop instead.
+	 *
+	 * @param args - Arguments for the resolver function.
+	 *
+	 * @returns The React component to render for a Slice.
+	 */
+	resolver?: SliceZoneResolver<TSlice, TContext>;
 
 	/**
 	 * The React component rendered if a component mapping from the `components`
@@ -178,19 +227,36 @@ export type SliceZoneProps<
  *
  * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
  * @typeParam TContext - Arbitrary data made available to all Slice components.
+ *
  * @returns The Slice Zone's content as React components.
+ *
  * @see Learn about Prismic Slices and Slice Zones {@link https://prismic.io/docs/core-concepts/slices}
  */
 export const SliceZone = <TSlice extends SliceLike, TContext>({
 	slices = [],
 	components = {} as SliceZoneComponents<TSlice, TContext>,
+	resolver,
 	defaultComponent = TODOSliceComponent,
 	context = {} as TContext,
 }: SliceZoneProps<TSlice, TContext>): JSX.Element => {
 	const renderedSlices = React.useMemo(() => {
 		return slices.map((slice, index) => {
-			const Comp = (components[slice.slice_type as keyof typeof components] ||
+			let Comp = (components[slice.slice_type as keyof typeof components] ||
 				defaultComponent) as SliceComponentType<TSlice, TContext>;
+
+			// TODO: Remove `resolver` in v3 in favor of `components`.
+			if (resolver) {
+				const resolvedComp = resolver({
+					slice,
+					sliceName: slice.slice_type,
+					i: index,
+				});
+
+				if (resolvedComp) {
+					Comp = resolvedComp;
+				}
+			}
+
 			const key = JSON.stringify(slice);
 
 			return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
 	SliceZoneComponents,
 	SliceZoneLike,
 	SliceZoneProps,
+	SliceZoneResolver,
 } from "./SliceZone";
 
 export { PrismicToolbar } from "./PrismicToolbar";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a `resolver` prop that matches that of `next-slicezone`. This change makes the migration path smoother for users upgrading existing projects.

It is marked as **deprecated** in favor of the `components` prop. `@prismicio/react`'s `<SliceZone>` will ultimately replace `next-slicezone`.

In a future major version, the `resolver` prop will be removed.

For reference, this is the type signature of the `resolver` function:

```typescript
/**
 * Arguments for a `<SliceZone>` `resolver` function.
 */
type SliceZoneResolverArgs<TSlice extends SliceLike = SliceLike> = {
	/**
	 * The Slice to resolve to a React component..
	 */
	slice: TSlice;

	/**
	 * The name of the Slice.
	 */
	sliceName: TSlice["slice_type"];

	/**
	 * The index of the Slice in the Slice Zone.
	 */
	i: number;
};

/**
 * A function that determines the rendered React component for each Slice in the
 * Slice Zone.
 *
 * @deprecated Use the `components` prop instead.
 *
 * @param args - Arguments for the resolver function.
 *
 * @returns The React component to render for a Slice.
 */
export type SliceZoneResolver<
	TSlice extends SliceLike = SliceLike,
	TContext = unknown,
> = (
	args: SliceZoneResolverArgs<TSlice>,
) => SliceComponentType<TSlice, TContext>;
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

🦊
