### PR TITLE
fix: render Slices in the correct order in `<SliceZone>`

### DIFF
--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -258,7 +258,7 @@ export const SliceZone = <TSlice extends SliceLike, TContext>({
 				}
 			}
 
-			const key = JSON.stringify(slice);
+			const key = `${index}-${JSON.stringify(slice)}`;
 
 			return (
 				<Comp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Related issue: #101

This PR fixes an issue where Slices could render in the wrong order in `<SliceZone>`.

The bug only occurs when the list of Slices changes after the first render. The bug occurs because the `key` prop is generated using the Slice's object. If multiple Slices contain the same payload (e.g. same Slice type, content, etc.), they would have duplicate keys.

To reduce the possibility of key collisions, this PR appends the Slice's index to the key.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

🔑
