### PR TITLE
fix: use pascalCase Slice type for `<SliceZone>` resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/helpers": "^2.0.0",
-				"@prismicio/richtext": "^2.0.0"
+				"@prismicio/richtext": "^2.0.0",
+				"tiny-case": "^1.0.2"
 			},
 			"devDependencies": {
 				"@prismicio/client": "^6.0.0",
@@ -46,6 +47,7 @@
 				"siroc": "^0.16.0",
 				"standard-version": "^9.3.2",
 				"ts-eager": "^2.0.2",
+				"type-fest": "^2.9.0",
 				"typescript": "^4.5.4"
 			},
 			"engines": {
@@ -4783,6 +4785,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globals/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9797,6 +9811,11 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/tiny-case": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.2.tgz",
+			"integrity": "sha512-XRlpLF8S2VuTqM8AbxvubIR+9dThYGDJ1d6hDM5F0LopIFIaxq8OFk9oAEljQjCJsrelJbBZXRKo0MFOqrEGqA=="
+		},
 		"node_modules/tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -9968,12 +9987,12 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.9.0.tgz",
+			"integrity": "sha512-uC0hJKi7eAGXUJ/YKk53RhnKxMwzHWgzf4t92oz8Qez28EBgVTfpDTB59y9hMYLzc/Wl85cD7Tv1hLZZoEJtrg==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14403,6 +14422,14 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+					"dev": true
+				}
 			}
 		},
 		"globby": {
@@ -18150,6 +18177,11 @@
 			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
 			"dev": true
 		},
+		"tiny-case": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.2.tgz",
+			"integrity": "sha512-XRlpLF8S2VuTqM8AbxvubIR+9dThYGDJ1d6hDM5F0LopIFIaxq8OFk9oAEljQjCJsrelJbBZXRKo0MFOqrEGqA=="
+		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -18280,9 +18312,9 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.9.0.tgz",
+			"integrity": "sha512-uC0hJKi7eAGXUJ/YKk53RhnKxMwzHWgzf4t92oz8Qez28EBgVTfpDTB59y9hMYLzc/Wl85cD7Tv1hLZZoEJtrg==",
 			"dev": true
 		},
 		"typedarray": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
 	"name": "@prismicio/react",
-	"version": "2.0.2",
+	"version": "2.0.3-debug.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prismicio/react",
-			"version": "2.0.2",
+			"version": "2.0.3-debug.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/helpers": "^2.0.0",
-				"@prismicio/richtext": "^2.0.0",
-				"tiny-case": "^1.0.2"
+				"@prismicio/richtext": "^2.0.0"
 			},
 			"devDependencies": {
 				"@prismicio/client": "^6.0.0",
@@ -9811,11 +9810,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/tiny-case": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.2.tgz",
-			"integrity": "sha512-XRlpLF8S2VuTqM8AbxvubIR+9dThYGDJ1d6hDM5F0LopIFIaxq8OFk9oAEljQjCJsrelJbBZXRKo0MFOqrEGqA=="
-		},
 		"node_modules/tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -18176,11 +18170,6 @@
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
 			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
 			"dev": true
-		},
-		"tiny-case": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.2.tgz",
-			"integrity": "sha512-XRlpLF8S2VuTqM8AbxvubIR+9dThYGDJ1d6hDM5F0LopIFIaxq8OFk9oAEljQjCJsrelJbBZXRKo0MFOqrEGqA=="
 		},
 		"tmp": {
 			"version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 	},
 	"dependencies": {
 		"@prismicio/helpers": "^2.0.0",
-		"@prismicio/richtext": "^2.0.0"
+		"@prismicio/richtext": "^2.0.0",
+		"tiny-case": "^1.0.2"
 	},
 	"devDependencies": {
 		"@prismicio/client": "^6.0.0",
@@ -82,6 +83,7 @@
 		"siroc": "^0.16.0",
 		"standard-version": "^9.3.2",
 		"ts-eager": "^2.0.2",
+		"type-fest": "^2.9.0",
 		"typescript": "^4.5.4"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
 	},
 	"dependencies": {
 		"@prismicio/helpers": "^2.0.0",
-		"@prismicio/richtext": "^2.0.0",
-		"tiny-case": "^1.0.2"
+		"@prismicio/richtext": "^2.0.0"
 	},
 	"devDependencies": {
 		"@prismicio/client": "^6.0.0",

--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as prismicT from "@prismicio/types";
+import type { PascalCase } from "type-fest";
 
 import { __PRODUCTION__ } from "./lib/__PRODUCTION__";
 import { pascalCase } from "./lib/pascalCase";

--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import * as prismicT from "@prismicio/types";
-import { pascalCase } from "tiny-case";
-import { PascalCase } from "type-fest";
 
 import { __PRODUCTION__ } from "./lib/__PRODUCTION__";
+import { pascalCase } from "./lib/pascalCase";
 
 /**
  * The minimum required properties to represent a Prismic Slice for the

--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -251,9 +251,7 @@ export const SliceZone = <TSlice extends SliceLike, TContext>({
 			if (resolver) {
 				const resolvedComp = resolver({
 					slice,
-					sliceName: pascalCase(slice.slice_type) as PascalCase<
-						typeof slice.slice_type
-					>,
+					sliceName: pascalCase(slice.slice_type),
 					i: index,
 				});
 

--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import * as prismicT from "@prismicio/types";
+import { pascalCase } from "tiny-case";
+import { PascalCase } from "type-fest";
 
 import { __PRODUCTION__ } from "./lib/__PRODUCTION__";
 
@@ -148,7 +150,7 @@ type SliceZoneResolverArgs<TSlice extends SliceLike = SliceLike> = {
 	/**
 	 * The name of the Slice.
 	 */
-	sliceName: TSlice["slice_type"];
+	sliceName: PascalCase<TSlice["slice_type"]>;
 
 	/**
 	 * The index of the Slice in the Slice Zone.
@@ -249,7 +251,9 @@ export const SliceZone = <TSlice extends SliceLike, TContext>({
 			if (resolver) {
 				const resolvedComp = resolver({
 					slice,
-					sliceName: slice.slice_type,
+					sliceName: pascalCase(slice.slice_type) as PascalCase<
+						typeof slice.slice_type
+					>,
 					i: index,
 				});
 
@@ -270,7 +274,7 @@ export const SliceZone = <TSlice extends SliceLike, TContext>({
 				/>
 			);
 		});
-	}, [components, context, defaultComponent, slices]);
+	}, [components, context, defaultComponent, slices, resolver]);
 
 	return <>{renderedSlices}</>;
 };

--- a/src/lib/pascalCase.ts
+++ b/src/lib/pascalCase.ts
@@ -1,0 +1,10 @@
+import { PascalCase } from "type-fest";
+
+export const pascalCase = <Input>(input: string): PascalCase<Input> => {
+	const camelCased = input.replace(/_/g, "-").replace(/-(\w)/g, (_, c) => {
+		return c ? c.toUpperCase() : "";
+	});
+
+	return (camelCased[0].toUpperCase() +
+		camelCased.slice(1)) as PascalCase<Input>;
+};

--- a/src/lib/pascalCase.ts
+++ b/src/lib/pascalCase.ts
@@ -1,7 +1,7 @@
 import type { PascalCase } from "type-fest";
 
 export const pascalCase = <Input>(input: string): PascalCase<Input> => {
-	const camelCased = input.replace(/_/g, "-").replace(/-(\w)/g, (_, c) => {
+	const camelCased = input.replace(/(?:-|_)(\w)/g, (_, c) => {
 		return c ? c.toUpperCase() : "";
 	});
 

--- a/src/lib/pascalCase.ts
+++ b/src/lib/pascalCase.ts
@@ -1,4 +1,4 @@
-import { PascalCase } from "type-fest";
+import type { PascalCase } from "type-fest";
 
 export const pascalCase = <Input>(input: string): PascalCase<Input> => {
 	const camelCased = input.replace(/_/g, "-").replace(/-(\w)/g, (_, c) => {

--- a/test/SliceZone.test.tsx
+++ b/test/SliceZone.test.tsx
@@ -179,6 +179,9 @@ test("renders components from a resolver function for backwards compatibility wi
 		{
 			slice_type: "barFoo",
 		},
+		{
+			slice_type: "baz-qux",
+		},
 	] as const;
 
 	const resolver: SliceZoneResolver<typeof slices[number]> = ({
@@ -191,6 +194,10 @@ test("renders components from a resolver function for backwards compatibility wi
 
 			case "BarFoo": {
 				return (props) => <StringifySliceComponent id="barFoo" {...props} />;
+			}
+
+			case "BazQux": {
+				return (props) => <StringifySliceComponent id="baz-qux" {...props} />;
 			}
 		}
 	};
@@ -209,6 +216,13 @@ test("renders components from a resolver function for backwards compatibility wi
 				id="barFoo"
 				slice={slices[1]}
 				index={1}
+				slices={slices}
+				context={{}}
+			/>
+			<StringifySliceComponent
+				id="baz-qux"
+				slice={slices[2]}
+				index={2}
 				slices={slices}
 				context={{}}
 			/>

--- a/test/SliceZone.test.tsx
+++ b/test/SliceZone.test.tsx
@@ -172,18 +172,25 @@ test.skip("TODO component does not warn in production", () => {
 });
 
 test("renders components from a resolver function for backwards compatibility with next-slicezone", async (t) => {
-	const slices = [{ slice_type: "foo" }, { slice_type: "bar" }] as const;
+	const slices = [
+		{
+			slice_type: "foo_bar",
+		},
+		{
+			slice_type: "barFoo",
+		},
+	] as const;
 
 	const resolver: SliceZoneResolver<typeof slices[number]> = ({
 		sliceName,
 	}) => {
 		switch (sliceName) {
-			case "Foo": {
-				return (props) => <StringifySliceComponent id="foo" {...props} />;
+			case "FooBar": {
+				return (props) => <StringifySliceComponent id="foo_bar" {...props} />;
 			}
 
-			case "Bar": {
-				return (props) => <StringifySliceComponent id="bar" {...props} />;
+			case "BarFoo": {
+				return (props) => <StringifySliceComponent id="barFoo" {...props} />;
 			}
 		}
 	};
@@ -192,14 +199,14 @@ test("renders components from a resolver function for backwards compatibility wi
 	const expected = renderJSON(
 		<>
 			<StringifySliceComponent
-				id="foo"
+				id="foo_bar"
 				slice={slices[0]}
 				index={0}
 				slices={slices}
 				context={{}}
 			/>
 			<StringifySliceComponent
-				id="bar"
+				id="barFoo"
 				slice={slices[1]}
 				index={1}
 				slices={slices}

--- a/test/SliceZone.test.tsx
+++ b/test/SliceZone.test.tsx
@@ -178,11 +178,11 @@ test("renders components from a resolver function for backwards compatibility wi
 		sliceName,
 	}) => {
 		switch (sliceName) {
-			case "foo": {
+			case "Foo": {
 				return (props) => <StringifySliceComponent id="foo" {...props} />;
 			}
 
-			case "bar": {
+			case "Bar": {
 				return (props) => <StringifySliceComponent id="bar" {...props} />;
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

`<SliceZone>`'s `resolve` prop is provided as a way to ease migration from `next-slicezone`. `next-slicezone`'s component uses a resolver function to convert a Slice's type to a React component. In this process, it converts the `slice_type` property into a pascalcased version.

This PR fixes a compatiblity issue by adding the pascalcase conversion.

*Note*: The `resolver` prop will be removed in a future version. When the prop is removed, the changes in this PR will also be removed.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐫
