### PR TITLE
fix: use .mjs module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
 	"exports": {
 		".": {
 			"require": "./dist/index.cjs",
-			"import": "./dist/index.js"
+			"import": "./dist/index.mjs"
 		},
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.cjs",
-	"module": "dist/index.js",
+	"module": "dist/index.mjs",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates the module exports to use `.mjs` rather than `.js`. This fixes an issue with Next.js 12 when deploying to Vercel (note that the problem only occurs in production).

`.mjs` originally was not used because it broken CRA 4. CRA 5 includes updates that resolves this issue (most likely the change to Webpack 5).

Related issues:
- https://github.com/prismicio/prismic-react/issues/108
- https://github.com/vercel/next.js/issues/30750

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
