### PR TITLE
fix: linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"build": "siroc build",
 		"dev": "siroc build --watch",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --ext .js,.jsx,.ts,.tsx .",
 		"prepare": "npm run build",
 		"release": "npm run build && npm run test && standard-version && git push --follow-tags && npm run build && npm publish",
 		"release:beta": "npm run build && npm run test && standard-version --release-as major --prerelease beta && git push --follow-tags && npm run build && npm publish --tag beta",

--- a/src/PrismicToolbar.tsx
+++ b/src/PrismicToolbar.tsx
@@ -45,7 +45,7 @@ export const PrismicToolbar = ({
 
 			document.body.appendChild(script);
 		}
-	}, [repositoryName, type]);
+	}, [repositoryName, type, src]);
 
 	return null;
 };

--- a/src/lib/pascalCase.ts
+++ b/src/lib/pascalCase.ts
@@ -1,6 +1,8 @@
 import type { PascalCase } from "type-fest";
 
-export const pascalCase = <Input>(input: string): PascalCase<Input> => {
+export const pascalCase = <Input extends string>(
+	input: Input,
+): PascalCase<Input> => {
 	const camelCased = input.replace(/(?:-|_)(\w)/g, (_, c) => {
 		return c ? c.toUpperCase() : "";
 	});


### PR DESCRIPTION
- chore: lint .tsx files
- fix: correct pascalCase type
- fix: resolve lint error in PrismicToolbar

<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a missing `useMemo` dependency in `<PrismicToolbar>`.

It also ensures .tsx files are linted during CI checks (which caught the missing dependency).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
