### PR TITLE
fix: automatically assign keys to custom `<PrismicRichText>` components

### DIFF
--- a/src/PrismicRichText.tsx
+++ b/src/PrismicRichText.tsx
@@ -240,7 +240,23 @@ export const PrismicRichText = (
 				defaultSerializer,
 			);
 
-			const serialized = prismicR.serialize(props.field, serializer);
+			// The serializer is wrapped in a higher-order function
+			// to automatically apply a key to React Elements if
+			// one is not already given.
+			const serialized = prismicR.serialize<JSX.Element>(
+				props.field,
+				(type, node, text, children, key) => {
+					const result = serializer(type, node, text, children, key);
+
+					if (React.isValidElement(result)) {
+						return React.cloneElement(result, {
+							key: result.key || key,
+						});
+					} else {
+						return result;
+					}
+				},
+			);
 
 			return <>{serialized}</>;
 		}

--- a/src/PrismicRichText.tsx
+++ b/src/PrismicRichText.tsx
@@ -224,11 +224,6 @@ export const PrismicRichText = (
 			return null;
 		} else {
 			const linkResolver = props.linkResolver || context.linkResolver;
-			const defaultSerializer = createDefaultSerializer({
-				linkResolver,
-				internalLinkComponent: props.internalLinkComponent,
-				externalLinkComponent: props.externalLinkComponent,
-			});
 
 			const serializer = prismicR.composeSerializers(
 				typeof props.components === "object"
@@ -237,21 +232,23 @@ export const PrismicRichText = (
 				typeof context.richTextComponents === "object"
 					? prismicR.wrapMapSerializer(context.richTextComponents)
 					: context.richTextComponents,
-				defaultSerializer,
+				createDefaultSerializer({
+					linkResolver,
+					internalLinkComponent: props.internalLinkComponent,
+					externalLinkComponent: props.externalLinkComponent,
+				}),
 			);
 
 			// The serializer is wrapped in a higher-order function
-			// to automatically apply a key to React Elements if
-			// one is not already given.
+			// that automatically applies a key to React Elements
+			// if one is not already given.
 			const serialized = prismicR.serialize<JSX.Element>(
 				props.field,
 				(type, node, text, children, key) => {
 					const result = serializer(type, node, text, children, key);
 
-					if (React.isValidElement(result)) {
-						return React.cloneElement(result, {
-							key: result.key || key,
-						});
+					if (React.isValidElement(result) && result.key == null) {
+						return React.cloneElement(result, { key });
 					} else {
 						return result;
 					}

--- a/test/PrismicRichText.test.tsx
+++ b/test/PrismicRichText.test.tsx
@@ -585,8 +585,8 @@ test("components given to components prop overrides components given to PrismicP
 	t.deepEqual(actual, expected);
 });
 
-// This test spies on `console.log()`. As a result, it must be run serially to
-// avoid affecting other tests.
+// This test spies on `console.error()`. As a result, it must be run serially
+// to avoid affecting other tests.
 test.serial("keys are automatically applied to custom components", (t) => {
 	const field: prismicT.RichTextField = [
 		{

--- a/test/PrismicRichText.test.tsx
+++ b/test/PrismicRichText.test.tsx
@@ -1,6 +1,7 @@
 import test from "ava";
 import * as prismicT from "@prismicio/types";
 import * as React from "react";
+import * as sinon from "sinon";
 
 import { renderJSON } from "./__testutils__/renderJSON";
 
@@ -582,4 +583,40 @@ test("components given to components prop overrides components given to PrismicP
 	);
 
 	t.deepEqual(actual, expected);
+});
+
+// This test spies on `console.log()`. As a result, it must be run serially to
+// avoid affecting other tests.
+test.serial("keys are automatically applied to custom components", (t) => {
+	const field: prismicT.RichTextField = [
+		{
+			type: prismicT.RichTextNodeType.heading1,
+			text: "heading1",
+			spans: [],
+		},
+		{
+			type: prismicT.RichTextNodeType.paragraph,
+			text: "paragraph",
+			spans: [],
+		},
+	];
+
+	const consoleErrorSpy = sinon.stub(console, "error");
+	consoleErrorSpy.callsFake(() => {
+		// no-op
+	});
+
+	renderJSON(
+		<PrismicRichText
+			field={field}
+			components={{
+				heading1: ({ children }) => <h1>{children}</h1>,
+				paragraph: ({ children }) => <p>{children}</p>,
+			}}
+		/>,
+	);
+
+	t.false(consoleErrorSpy.calledWith(sinon.match(/unique "key"/)));
+
+	consoleErrorSpy.restore();
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR automatically applies keys to custom components provided to `<PrismicRichText>`. Without the PR, React logs an error about missing keys if the a `key` prop is not explicitly given to each component.

More details: #114

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐺
