### PR TITLE
fix: remove ESM `package.json` declaration (fixes `'Element' is not exported from '@prismicio/richtext'`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,16 +16,15 @@
 	"license": "Apache-2.0",
 	"author": "Prismic <contact@prismic.io> (https://prismic.io)",
 	"sideEffects": false,
-	"type": "module",
 	"exports": {
 		".": {
 			"require": "./dist/index.cjs",
-			"import": "./dist/index.mjs"
+			"import": "./dist/index.js"
 		},
 		"./package.json": "./package.json"
 	},
 	"main": "dist/index.cjs",
-	"module": "dist/index.mjs",
+	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR removes the explicit ES Module declaration by removing `"type": "module"` from `package.json`.

Declaring the package as an ES Module has caused issues in the following circumstances:

- **Next.js on Vercel**: The entry file must use the `.mjs` extension to resolve correctly during server-rendered requests. This causes issues in build systems that do not recognize `.mjs` (e.g. Create React App). This only happens when deployed to Vercel in production. (See #108)
- **Create React App 4**: `.mjs` files are unsupported. It works with a `.js` file extension, which breaks Next.js support.
- **Create React App 5**: `.mjs` with `"type": "module"` is supported, but breaks backwards compatibility with CRA 4.

The most straightforward solution that ensures everything works out-of-the-box is to remove `"type": "module"` from `package.json`. When the ecosystem is more aligned behind ESM, we can restore it to a proper ES Module.

Fixes #117

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🙃
