### PR TITLE
fix: forward refs to `<PrismicLink>` components

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -6,6 +6,12 @@ import { isInternalURL } from "./lib/isInternalURL";
 
 import { usePrismicContext } from "./usePrismicContext";
 
+declare module "react" {
+	function forwardRef<T, P = Record<string, never>>(
+		render: (props: P, ref: React.Ref<T>) => JSX.Element | null,
+	): (props: P & React.RefAttributes<T>) => JSX.Element | null;
+}
+
 /**
  * Props provided to a component when rendered with `<PrismicLink>`.
  */
@@ -132,7 +138,7 @@ const defaultExternalComponent = "a";
  * @returns The internal or external link component depending on whether the
  *   link is internal or external.
  */
-export const PrismicLink = <
+const _PrismicLink = <
 	InternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
 	ExternalComponent extends React.ElementType<LinkProps> = typeof defaultExternalComponent,
 	LinkResolverFunction extends prismicH.LinkResolverFunction = prismicH.LinkResolverFunction,
@@ -142,6 +148,7 @@ export const PrismicLink = <
 		ExternalComponent,
 		LinkResolverFunction
 	>,
+	ref: React.ForwardedRef<any>,
 ): JSX.Element | null => {
 	const context = usePrismicContext();
 
@@ -196,6 +203,14 @@ export const PrismicLink = <
 	}
 
 	return href ? (
-		<Component {...passthroughProps} href={href} target={target} rel={rel} />
+		<Component
+			{...passthroughProps}
+			ref={ref}
+			href={href}
+			target={target}
+			rel={rel}
+		/>
 	) : null;
 };
+
+export const PrismicLink = React.forwardRef(_PrismicLink);

--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -6,6 +6,10 @@ import { isInternalURL } from "./lib/isInternalURL";
 
 import { usePrismicContext } from "./usePrismicContext";
 
+// This module-specific `forwardRef()` type override adds support for
+// components using generics in its props type.
+//
+// Other modules will not be affected.
 declare module "react" {
 	function forwardRef<T, P = Record<string, never>>(
 		render: (props: P, ref: React.Ref<T>) => JSX.Element | null,
@@ -142,13 +146,30 @@ const _PrismicLink = <
 	InternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
 	ExternalComponent extends React.ElementType<LinkProps> = typeof defaultExternalComponent,
 	LinkResolverFunction extends prismicH.LinkResolverFunction = prismicH.LinkResolverFunction,
+	Ref extends
+		| (InternalComponent extends keyof HTMLElementTagNameMap
+				? HTMLElementTagNameMap[InternalComponent]
+				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+				  any)
+		| (ExternalComponent extends keyof HTMLElementTagNameMap
+				? HTMLElementTagNameMap[ExternalComponent]
+				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+				  any) =
+		| (InternalComponent extends keyof HTMLElementTagNameMap
+				? HTMLElementTagNameMap[InternalComponent]
+				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+				  any)
+		| (ExternalComponent extends keyof HTMLElementTagNameMap
+				? HTMLElementTagNameMap[ExternalComponent]
+				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+				  any),
 >(
 	props: PrismicLinkProps<
 		InternalComponent,
 		ExternalComponent,
 		LinkResolverFunction
 	>,
-	ref: React.ForwardedRef<any>,
+	ref: React.ForwardedRef<Ref>,
 ): JSX.Element | null => {
 	const context = usePrismicContext();
 
@@ -204,6 +225,11 @@ const _PrismicLink = <
 
 	return href ? (
 		<Component
+			// @ts-expect-error - Expression produces a union type
+			// that is too complex to represent. This most likely
+			// happens due to the polymorphic nature of this
+			// component, passing of "extra" props, and ref
+			// forwarding support.
 			{...passthroughProps}
 			ref={ref}
 			href={href}

--- a/test/PrismicLink.test.tsx
+++ b/test/PrismicLink.test.tsx
@@ -347,3 +347,77 @@ test("renders null if href is provided undefined", (t) => {
 
 	t.is(actual, null);
 });
+
+test("forwards ref to internal component", (t) => {
+	const CustomComponent =
+		// eslint-disable-next-line react/display-name
+		React.forwardRef(
+			(props: { href?: string }, ref: React.Ref<HTMLInputElement>) => {
+				return <input ref={ref} value={props.href} />;
+			},
+		);
+
+	let aRef = null as HTMLAnchorElement | null;
+	let spanRef = null as HTMLSpanElement | null;
+	let customComponentRef = null as HTMLInputElement | null;
+
+	renderJSON(
+		<>
+			<PrismicLink ref={(el) => (aRef = el)} href="/" />
+			<PrismicLink
+				ref={(el) => (spanRef = el)}
+				internalComponent="span"
+				href="/"
+			/>
+			<PrismicLink
+				ref={(el) => (customComponentRef = el)}
+				internalComponent={CustomComponent}
+				href="/"
+			/>
+		</>,
+		{
+			createNodeMock: (element) => ({ tagName: element.type }),
+		},
+	);
+
+	t.is(aRef?.tagName, "a");
+	t.is(spanRef?.tagName, "span");
+	t.is(customComponentRef?.tagName, "input");
+});
+
+test("forwards ref to external component", (t) => {
+	const CustomComponent =
+		// eslint-disable-next-line react/display-name
+		React.forwardRef(
+			(props: { href?: string }, ref: React.Ref<HTMLInputElement>) => {
+				return <input ref={ref} value={props.href} />;
+			},
+		);
+
+	let aRef = null as HTMLAnchorElement | null;
+	let spanRef = null as HTMLSpanElement | null;
+	let customComponentRef = null as HTMLInputElement | null;
+
+	renderJSON(
+		<>
+			<PrismicLink ref={(el) => (aRef = el)} href="https://prismic.io" />
+			<PrismicLink
+				ref={(el) => (spanRef = el)}
+				externalComponent="span"
+				href="https://prismic.io"
+			/>
+			<PrismicLink
+				ref={(el) => (customComponentRef = el)}
+				externalComponent={CustomComponent}
+				href="https://prismic.io"
+			/>
+		</>,
+		{
+			createNodeMock: (element) => ({ tagName: element.type }),
+		},
+	);
+
+	t.is(aRef?.tagName, "a");
+	t.is(spanRef?.tagName, "span");
+	t.is(customComponentRef?.tagName, "input");
+});

--- a/test/__testutils__/renderJSON.ts
+++ b/test/__testutils__/renderJSON.ts
@@ -10,11 +10,12 @@ import * as renderer from "react-test-renderer";
  */
 export const renderJSON = (
 	element: React.ReactElement,
+	options?: renderer.TestRendererOptions,
 ): renderer.ReactTestRendererJSON | renderer.ReactTestRendererJSON[] | null => {
 	let root: renderer.ReactTestRenderer;
 
 	renderer.act(() => {
-		root = renderer.create(element);
+		root = renderer.create(element, options);
 	});
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for forwarding refs to `<PrismicLink>` components. Before this PR, refs were ignored, meaning there was no way to target the rendered element.

In the following example, `ref` will contain a reference to the rendered `<a>` element.

```tsx
const Page = ({ document }) => {
  const ref = useRef(null);

  return (
    <PrismicLink ref={ref} field={document.data.link}>
      Click me!
    </PrismicLink>
  );
};
```

If a custom component is provided, the ref will be passed to the component. The custom component must handle the ref forwarding itself.


```tsx
const CustomComponent = React.forwardRef(({ href, children }, ref) => {
  return <span ref={ref}>{children}</span>;
});

const Page = ({ document }) => {
  const ref = useRef(null);

  return (
    <PrismicLink
      ref={ref}
      field={document.data.link}
      internalComponent={CustomComponent}
    >
      Click me!
    </PrismicLink>
  );
};
```

This works for both internal and external components. If you are using TypeScript, note that this means the ref must be typed for both the rendered internal and external components.

Fixes #128 

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐡
