### PR TITLE
fix: better support for custom `<PrismicLink>` components using `forwardRef()`

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -6,16 +6,6 @@ import { isInternalURL } from "./lib/isInternalURL";
 
 import { usePrismicContext } from "./usePrismicContext";
 
-// This module-specific `forwardRef()` type override adds support for
-// components using generics in its props type.
-//
-// Other modules will not be affected.
-declare module "react" {
-	function forwardRef<T, P = Record<string, never>>(
-		render: (props: P, ref: React.Ref<T>) => JSX.Element | null,
-	): (props: P & React.RefAttributes<T>) => JSX.Element | null;
-}
-
 /**
  * Props provided to a component when rendered with `<PrismicLink>`.
  */
@@ -51,8 +41,8 @@ export type PrismicLinkProps<
 	ExternalComponent extends React.ElementType<LinkProps> = React.ElementType<LinkProps>,
 	LinkResolverFunction extends prismicH.LinkResolverFunction = prismicH.LinkResolverFunction,
 > = Omit<
-	React.ComponentProps<InternalComponent> &
-		React.ComponentProps<ExternalComponent>,
+	React.ComponentPropsWithoutRef<InternalComponent> &
+		React.ComponentPropsWithoutRef<ExternalComponent>,
 	keyof LinkProps
 > & {
 	/**
@@ -146,30 +136,14 @@ const _PrismicLink = <
 	InternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
 	ExternalComponent extends React.ElementType<LinkProps> = typeof defaultExternalComponent,
 	LinkResolverFunction extends prismicH.LinkResolverFunction = prismicH.LinkResolverFunction,
-	Ref extends
-		| (InternalComponent extends keyof HTMLElementTagNameMap
-				? HTMLElementTagNameMap[InternalComponent]
-				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-				  any)
-		| (ExternalComponent extends keyof HTMLElementTagNameMap
-				? HTMLElementTagNameMap[ExternalComponent]
-				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-				  any) =
-		| (InternalComponent extends keyof HTMLElementTagNameMap
-				? HTMLElementTagNameMap[InternalComponent]
-				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-				  any)
-		| (ExternalComponent extends keyof HTMLElementTagNameMap
-				? HTMLElementTagNameMap[ExternalComponent]
-				: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-				  any),
 >(
 	props: PrismicLinkProps<
 		InternalComponent,
 		ExternalComponent,
 		LinkResolverFunction
 	>,
-	ref: React.ForwardedRef<Ref>,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	ref: React.Ref<any>,
 ): JSX.Element | null => {
 	const context = usePrismicContext();
 
@@ -239,4 +213,14 @@ const _PrismicLink = <
 	) : null;
 };
 
-export const PrismicLink = React.forwardRef(_PrismicLink);
+export const PrismicLink = React.forwardRef(_PrismicLink) as <
+	InternalComponent extends React.ElementType<LinkProps>,
+	ExternalComponent extends React.ElementType<LinkProps>,
+	LinkResolverFunction extends prismicH.LinkResolverFunction,
+>(
+	props: PrismicLinkProps<
+		InternalComponent,
+		ExternalComponent,
+		LinkResolverFunction
+	> & { ref?: React.Ref<Element> },
+) => JSX.Element | null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a regression introduced by #131. Due to the way #131 implemented type-parameter-aware ref forwarding, projects using `@prismicio/react` could not manually declare a component's `displayName` property.

This PR also fixes a type bug related to the `ref` prop. It widens the ref element type to `Element` to support any valid HTML/SVG/etc. element. Note that an individual `<PrismicLink>` may not have enough information to determine which component is rendered since custom components can be provided to `<PrismicProvider>`. `Element` is the safest option.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
