### PR TITLE
feat: support Prismic's GraphQL API in `<SliceZone>`

### DIFF
--- a/test/SliceZone.test.tsx
+++ b/test/SliceZone.test.tsx
@@ -231,3 +231,37 @@ test("renders components from a resolver function for backwards compatibility wi
 
 	t.deepEqual(actual, expected);
 });
+
+test("supports the GraphQL API", (t) => {
+	const slices = [{ type: "foo" }, { type: "bar" }] as const;
+
+	const actual = renderJSON(
+		<SliceZone
+			slices={slices}
+			components={{
+				foo: (props) => <StringifySliceComponent id="foo" {...props} />,
+				bar: (props) => <StringifySliceComponent id="bar" {...props} />,
+			}}
+		/>,
+	);
+	const expected = renderJSON(
+		<>
+			<StringifySliceComponent
+				id="foo"
+				slice={slices[0]}
+				index={0}
+				slices={slices}
+				context={{}}
+			/>
+			<StringifySliceComponent
+				id="bar"
+				slice={slices[1]}
+				index={1}
+				slices={slices}
+				context={{}}
+			/>
+		</>,
+	);
+
+	t.deepEqual(actual, expected);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for Prismic's GraphQL API when using `<SliceZone>`.

The GraphQL API returns Slices with the following shape:

```json
{
  "type": "foo",
  "label": "bar",
  "primary": {},
  "items": []
}
```

The Rest API returns Slices with the following shape:

```json
{
  "slice_type": "foo",
  "slice_label": "bar",
  "primary": {},
  "items": []
}
```

To support the GraphQL API, `<SliceZone>` can now read a Slice's `slice_type` or `type` property to determine which component to render.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐙
