### PR TITLE
fix: correct types for non-string Link Resolver functions

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -39,7 +39,8 @@ export interface LinkProps {
 export type PrismicLinkProps<
 	InternalComponent extends React.ElementType<LinkProps> = React.ElementType<LinkProps>,
 	ExternalComponent extends React.ElementType<LinkProps> = React.ElementType<LinkProps>,
-	LinkResolverFunction extends prismicH.LinkResolverFunction = prismicH.LinkResolverFunction,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
 > = Omit<
 	React.ComponentPropsWithoutRef<InternalComponent> &
 		React.ComponentPropsWithoutRef<ExternalComponent>,
@@ -133,9 +134,10 @@ const defaultExternalComponent = "a";
  *   link is internal or external.
  */
 const _PrismicLink = <
-	InternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
-	ExternalComponent extends React.ElementType<LinkProps> = typeof defaultExternalComponent,
-	LinkResolverFunction extends prismicH.LinkResolverFunction = prismicH.LinkResolverFunction,
+	InternalComponent extends React.ElementType<LinkProps>,
+	ExternalComponent extends React.ElementType<LinkProps>,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any>,
 >(
 	props: PrismicLinkProps<
 		InternalComponent,
@@ -216,7 +218,8 @@ const _PrismicLink = <
 export const PrismicLink = React.forwardRef(_PrismicLink) as <
 	InternalComponent extends React.ElementType<LinkProps>,
 	ExternalComponent extends React.ElementType<LinkProps>,
-	LinkResolverFunction extends prismicH.LinkResolverFunction,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any>,
 >(
 	props: PrismicLinkProps<
 		InternalComponent,

--- a/src/PrismicProvider.tsx
+++ b/src/PrismicProvider.tsx
@@ -10,7 +10,10 @@ import { JSXFunctionSerializer, JSXMapSerializer } from "./types";
  * React context value containing shared configuration for `@prismicio/react`
  * components and hooks.
  */
-export type PrismicContextValue = {
+export type PrismicContextValue<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
+> = {
 	/**
 	 * A `@prismicio/client` instance used to fetch content from a Prismic
 	 * repository. This is used by `@prismicio/react` hooks, such as
@@ -26,7 +29,7 @@ export type PrismicContextValue = {
 	 * repository's content, a Link Resolver does not need to be provided.
 	 * @see Learn about Link Resolvers and Route Resolvers {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver}
 	 */
-	linkResolver?: prismicH.LinkResolverFunction;
+	linkResolver?: LinkResolverFunction;
 
 	/**
 	 * A map or function that maps a Rich Text block to a React component.
@@ -81,7 +84,9 @@ export const PrismicContext = React.createContext<PrismicContextValue>({});
 /**
  * Props for `<PrismicProvider>`.
  */
-export type PrismicProviderProps = PrismicContextValue;
+export type PrismicProviderProps<
+	LinkResolverFunction extends prismicH.LinkResolverFunction,
+> = PrismicContextValue<LinkResolverFunction>;
 
 /**
  * React context provider to share configuration for `@prismicio/react`
@@ -89,15 +94,18 @@ export type PrismicProviderProps = PrismicContextValue;
  *
  * @returns A React context provider with shared configuration.
  */
-export const PrismicProvider = ({
+export const PrismicProvider = <
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any>,
+>({
 	client,
 	linkResolver,
 	richTextComponents,
 	internalLinkComponent,
 	externalLinkComponent,
 	children,
-}: PrismicProviderProps): JSX.Element => {
-	const value = React.useMemo<PrismicContextValue>(
+}: PrismicProviderProps<LinkResolverFunction>): JSX.Element => {
+	const value = React.useMemo<PrismicContextValue<LinkResolverFunction>>(
 		() => ({
 			client,
 			linkResolver,

--- a/src/PrismicRichText.tsx
+++ b/src/PrismicRichText.tsx
@@ -13,7 +13,10 @@ import { usePrismicContext } from "./usePrismicContext";
 /**
  * Props for `<PrismicRichText>`.
  */
-export type PrismicRichTextProps = {
+export type PrismicRichTextProps<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
+> = {
 	/**
 	 * The Prismic Rich Text field to render.
 	 */
@@ -27,7 +30,7 @@ export type PrismicRichTextProps = {
 	 * repository's content, a Link Resolver does not need to be provided.
 	 * @see Learn about Link Resolvers and Route Resolvers {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver}
 	 */
-	linkResolver?: PrismicLinkProps["linkResolver"];
+	linkResolver?: LinkResolverFunction;
 
 	/**
 	 * A function that maps a Rich Text block to a React component.
@@ -87,8 +90,11 @@ export type PrismicRichTextProps = {
 	fallback?: React.ReactNode;
 };
 
-type CreateDefaultSerializerArgs = {
-	linkResolver: prismicH.LinkResolverFunction<string> | undefined;
+type CreateDefaultSerializerArgs<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
+> = {
+	linkResolver: LinkResolverFunction | undefined;
 	internalLinkComponent: PrismicRichTextProps["internalLinkComponent"];
 	externalLinkComponent: PrismicRichTextProps["externalLinkComponent"];
 };
@@ -220,8 +226,11 @@ const createDefaultSerializer = (
  * @see Learn about Rich Text fields {@link https://prismic.io/docs/core-concepts/rich-text-title}
  * @see Learn about Rich Text serializers {@link https://prismic.io/docs/core-concepts/html-serializer}
  */
-export const PrismicRichText = (
-	props: PrismicRichTextProps,
+export const PrismicRichText = <
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
+>(
+	props: PrismicRichTextProps<LinkResolverFunction>,
 ): JSX.Element | null => {
 	const context = usePrismicContext();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a TypeScript type bug where provided Link Resolvers were not allowed to return anything except `string`.

The following components that accept a Link Resolver function have been fixed:

- `PrismicProvider`
- `PrismicRichText`
- `PrismicLink`

Fixes #137

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐟
