### PR TITLE
fix: restore default `React.AnchorHTMLAttributes` props on `<PrismicLink>`

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -38,8 +38,8 @@ export interface LinkProps {
  * Props for `<PrismicLink>`.
  */
 export type PrismicLinkProps<
-	InternalComponent extends React.ElementType<LinkProps> = React.ElementType<LinkProps>,
-	ExternalComponent extends React.ElementType<LinkProps> = React.ElementType<LinkProps>,
+	InternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
+	ExternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
 > = Omit<
@@ -120,10 +120,10 @@ const defaultInternalComponent = "a";
 const defaultExternalComponent = "a";
 
 const _PrismicLink = <
-	InternalComponent extends React.ElementType<LinkProps>,
-	ExternalComponent extends React.ElementType<LinkProps>,
+	InternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
+	ExternalComponent extends React.ElementType<LinkProps> = typeof defaultExternalComponent,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	LinkResolverFunction extends prismicH.LinkResolverFunction<any>,
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
 >(
 	props: PrismicLinkProps<
 		InternalComponent,
@@ -221,10 +221,10 @@ if (!__PRODUCTION__) {
  *   link is internal or external.
  */
 export const PrismicLink = React.forwardRef(_PrismicLink) as <
-	InternalComponent extends React.ElementType<LinkProps>,
-	ExternalComponent extends React.ElementType<LinkProps>,
+	InternalComponent extends React.ElementType<LinkProps> = typeof defaultInternalComponent,
+	ExternalComponent extends React.ElementType<LinkProps> = typeof defaultExternalComponent,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	LinkResolverFunction extends prismicH.LinkResolverFunction<any>,
+	LinkResolverFunction extends prismicH.LinkResolverFunction<any> = prismicH.LinkResolverFunction,
 >(
 	props: PrismicLinkProps<
 		InternalComponent,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR restores the default `React.AnchorHTMLAttributes` props on `<PrismicLink>`. This brings back support for common props like `className` and `onClick`.

See #145 for more details.

---

If you use `<PrismicLink>` with a component that does not behave like `<a>` (for example, it does not accept props for `className` or `onClick`), the following strategies can be used in your project.

In all three strategies, you would use a custom `<PrismicLink>` implementation built off `<PrismicLink>` provided by `@prismicio/react`.

## 1. Custom `<PrismicLink>` using global configuration and TypeScript 4.7 Instantiation Expressions

(Note: This assumes PrismicLink is configured globally via `<PrismicProvider>` to render `<Link>` for internal links.)

You can take advantage of [TypeScript 4.7's Instantiation Expressions](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-beta/#instantiation-expressions) feature to define a custom instance of `<PrismicLink>` specific to your internal and external link React components.

`react-router-dom`'s `<Link>` is used as an example below, but this could be any component.

```tsx
// src/components/PrismicLink.tsx

import { PrismicLink as PrismicLinkBase } from "@prismicio/react";
import { Link } from "react-router-dom";

export const PrismicLink = PrismicLinkBase<typeof Link>;
```

TypeScript 4.7 is currently in beta, and we cannot expect users to always be using the latest version of TypeScript. As such, this solution will not apply to everyone.

## 2. Custom `<PrismicLink>` using global configuration and type parameters in JSX

(Note: This assumes PrismicLink is configured globally via `<PrismicProvider>` to render `<Link>` for internal links.)

Similar to the above solution, a custom instance of `<PrismicLink>` can be created with the correct generic. This does not rely on bleeding-edge TypeScript features.

```tsx
// src/components/PrismicLink.tsx

import {
  PrismicLink as PrismicLinkBase,
  PrismicLinkProps,
} from "@prismicio/react";
import { Link } from "react-router-dom";

export const PrismicLink = (props: PrismicLinkProps<typeof Link>) => (
  <PrismicLinkBase<typeof Link> {...props} />
);
```

## 3. Custom `<PrismicLink>` using non-global configuration

(Note: This assumes PrismicLink is **_not_** configured globally via `<PrismicProvider>` to render `<Link>` for internal links.)

Alternatively, a custom PrismicLink instance could be configured by passing the internal/external React components directly. This ignores any global configuration provided to `<PrismicProvider>`.

```tsx
// src/components/PrismicLink.tsx

import {
  PrismicLink as PrismicLinkBase,
  PrismicLinkProps,
} from "@prismicio/react";
import { Link } from "react-router-dom";

export const PrismicLink = (props: PrismicLinkProps<typeof Link>) => (
  <PrismicLinkBase internalComponent={Link} {...props} />
);
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
