### PR TITLE
feat(PrismicLink): automatically set `target="_blank" rel="noopener noreferrer"` when `href` is external

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -146,13 +146,16 @@ const _PrismicLink = <
 		href = prismicH.asLink(props.field, linkResolver);
 	}
 
-	const target =
-		props.target ||
-		("field" in props &&
-			props.field &&
-			"target" in props.field &&
-			props.field.target) ||
-		undefined;
+	const isInternal = href && isInternalURL(href);
+
+	let target = undefined;
+	if (props.target) {
+		target = props.target;
+	} else if ("field" in props && props.field && "target" in props.field) {
+		target = props.field.target;
+	} else if (!isInternal) {
+		target = "_blank";
+	}
 
 	const rel =
 		props.rel || (target === "_blank" ? "noopener noreferrer" : undefined);
@@ -166,8 +169,6 @@ const _PrismicLink = <
 		props.externalComponent ||
 		context.externalLinkComponent ||
 		defaultExternalComponent;
-
-	const isInternal = href && isInternalURL(href);
 
 	const Component = isInternal ? InternalComponent : ExternalComponent;
 

--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -148,14 +148,14 @@ const _PrismicLink = <
 
 	const isInternal = href && isInternalURL(href);
 
-	let target = undefined;
-	if (props.target) {
-		target = props.target;
-	} else if ("field" in props && props.field && "target" in props.field) {
-		target = props.field.target;
-	} else if (!isInternal) {
-		target = "_blank";
-	}
+	const target =
+		props.target ||
+		("field" in props &&
+			props.field &&
+			"target" in props.field &&
+			props.field.target) ||
+		(!isInternal && "_blank") ||
+		undefined;
 
 	const rel =
 		props.rel || (target === "_blank" ? "noopener noreferrer" : undefined);

--- a/test/PrismicLink.test.tsx
+++ b/test/PrismicLink.test.tsx
@@ -20,7 +20,7 @@ test("renders a link from a document link field", (t) => {
 		tags: [],
 		type: "page",
 		link_type: prismicT.LinkType.Document,
-		url: "url",
+		url: "/url",
 	};
 
 	const actual = renderJSON(<PrismicLink field={field} />);
@@ -34,7 +34,7 @@ test("renders a link from a document link field", (t) => {
 test("renders a link from a media link field", (t) => {
 	const field: prismicT.FilledLinkToMediaField = {
 		link_type: prismicT.LinkType.Media,
-		url: "url",
+		url: "/url",
 		kind: "kind",
 		name: "name",
 		size: "size",
@@ -50,7 +50,7 @@ test("renders a link from a media link field", (t) => {
 
 test("renders a link from a web link field", (t) => {
 	const field: prismicT.FilledLinkToWebField = {
-		url: "url",
+		url: "/url",
 		link_type: prismicT.LinkType.Web,
 	};
 
@@ -63,10 +63,8 @@ test("renders a link from a web link field", (t) => {
 });
 
 test("renders a link from a document with a URL", (t) => {
-	const document = prismicM.value.document({
-		seed: t.title,
-		withURL: true,
-	});
+	const document = prismicM.value.document({ seed: t.title });
+	document.url = "/url";
 
 	const actual = renderJSON(<PrismicLink document={document} />);
 	const expected = renderJSON(
@@ -101,9 +99,9 @@ test("renders a link from a document using a Link Resolver", (t) => {
 });
 
 test("renders link from an href", (t) => {
-	const actual = renderJSON(<PrismicLink href="href" />);
+	const actual = renderJSON(<PrismicLink href="/href" />);
 	const expected = renderJSON(
-		<a href="href" rel={undefined} target={undefined} />,
+		<a href="/href" rel={undefined} target={undefined} />,
 	);
 
 	t.deepEqual(actual, expected);
@@ -117,12 +115,12 @@ test("prefers explicit href over field", (t) => {
 		tags: [],
 		type: "page",
 		link_type: prismicT.LinkType.Document,
-		url: "url",
+		url: "/url",
 	};
 
-	const actual = renderJSON(<PrismicLink href="href" field={field} />);
+	const actual = renderJSON(<PrismicLink href="/href" field={field} />);
 	const expected = renderJSON(
-		<a href="href" rel={undefined} target={undefined} />,
+		<a href="/href" rel={undefined} target={undefined} />,
 	);
 
 	t.deepEqual(actual, expected);
@@ -174,7 +172,7 @@ test("uses link resolver provided via props", (t) => {
 
 test("if given a link field value with _blank target, use target and include rel='noopener noreferrer'", (t) => {
 	const field: prismicT.FilledLinkToWebField = {
-		url: "url",
+		url: "/url",
 		link_type: prismicT.LinkType.Web,
 		target: "_blank",
 	};
@@ -189,7 +187,7 @@ test("if given a link field value with _blank target, use target and include rel
 
 test("allow overriding default rel", (t) => {
 	const field: prismicT.FilledLinkToWebField = {
-		url: "url",
+		url: "/url",
 		link_type: prismicT.LinkType.Web,
 		target: "_blank",
 	};
@@ -205,7 +203,7 @@ test("allow overriding default rel", (t) => {
 
 test("allow overriding default target", (t) => {
 	const field: prismicT.FilledLinkToWebField = {
-		url: "url",
+		url: "/url",
 		link_type: prismicT.LinkType.Web,
 		target: "_blank",
 	};
@@ -220,13 +218,22 @@ test("allow overriding default target", (t) => {
 
 test("if manually given _blank to target, use rel'noopener norefferer", (t) => {
 	const field: prismicT.FilledLinkToWebField = {
-		url: "url",
+		url: "/url",
 		link_type: prismicT.LinkType.Web,
 	};
 
 	const actual = renderJSON(<PrismicLink field={field} target="_blank" />);
 	const expected = renderJSON(
-		<a href={field.url} target="_blank" rel={"noopener noreferrer"} />,
+		<a href={field.url} target="_blank" rel="noopener noreferrer" />,
+	);
+
+	t.deepEqual(actual, expected);
+});
+
+test('if target is not explicitly provided and the URL is external, use target="_blank" and rel="noopener noreferrer"', (t) => {
+	const actual = renderJSON(<PrismicLink href="https://example.com" />);
+	const expected = renderJSON(
+		<a href="https://example.com" target="_blank" rel="noopener noreferrer" />,
 	);
 
 	t.deepEqual(actual, expected);
@@ -281,7 +288,7 @@ test("if URL is internal and internalComponent is given to the provider and the 
 test("if URL is external and no externalComponent is given, render an <a>", (t) => {
 	const actual = renderJSON(<PrismicLink href="https://example.com" />);
 	const expected = renderJSON(
-		<a href="https://example.com" rel={undefined} target={undefined} />,
+		<a href="https://example.com" rel="noopener noreferrer" target="_blank" />,
 	);
 
 	t.deepEqual(actual, expected);
@@ -292,7 +299,11 @@ test("if URL is external and externalComponent is given, render externalComponen
 		<PrismicLink href="https://example.com" externalComponent={Link} />,
 	);
 	const expected = renderJSON(
-		<Link href="https://example.com" rel={undefined} target={undefined} />,
+		<Link
+			href="https://example.com"
+			rel="noopener noreferrer"
+			target="_blank"
+		/>,
 	);
 
 	t.deepEqual(actual, expected);
@@ -305,7 +316,11 @@ test("if URL is external and externalComponent is given to the provider, render 
 		</PrismicProvider>,
 	);
 	const expected = renderJSON(
-		<Link href="https://example.com" rel={undefined} target={undefined} />,
+		<Link
+			href="https://example.com"
+			rel="noopener noreferrer"
+			target="_blank"
+		/>,
 	);
 
 	t.deepEqual(actual, expected);
@@ -318,7 +333,11 @@ test("if URL is external and externalComponent is given to the provider and the 
 		</PrismicProvider>,
 	);
 	const expected = renderJSON(
-		<Link href="https://example.com" rel={undefined} target={undefined} />,
+		<Link
+			href="https://example.com"
+			rel="noopener noreferrer"
+			target="_blank"
+		/>,
 	);
 
 	t.deepEqual(actual, expected);

--- a/test/PrismicRichText.test.tsx
+++ b/test/PrismicRichText.test.tsx
@@ -419,7 +419,7 @@ test("Returns <PrismicLink /> when type is hyperlink", (t) => {
 		tags: [],
 		type: "page",
 		link_type: prismicT.LinkType.Document,
-		url: "url",
+		url: "/url",
 	};
 
 	const field: prismicT.RichTextField = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds functionality to automatic set `target="_blank" rel="noopener noreferrer"` when `href` is an external URL.

```tsx
<PrismicLink href="https://example.com">External</PrismicLink>
// <a href="https://example.com" target="_blank" rel="noopener noreferrer">External</a>
```

This behavior applies to both the `href` and `field` props. In the following example, assume `doc.data.linkField` resolves to an external URL.

```tsx
<PrismicLink field={doc.data.linkField}>External</PrismicLink>
// <a href="https://example.com" target="_blank" rel="noopener noreferrer">External</a>
```

`target` and `rel` can always be overriden by passing these props directly.

```tsx
<PrismicLink href="https://example.com" target={undefined}>
  External
</PrismicLink>;
// <a href="https://example.com">External</a>

<PrismicLink href="https://example.com" rel="help">
  External
</PrismicLink>;
// <a href="https://example.com" target="_blank" rel="help">External</a>
```

This functionality was intended to ship with the initial `<PrismicLink>` releaes, but it was accidentally left out.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦮
