### PR TITLE
fix: do not execute `<PrismicToolbar>`'s script during Happy DOM tests

### DIFF
--- a/src/PrismicToolbar.tsx
+++ b/src/PrismicToolbar.tsx
@@ -43,7 +43,8 @@ export const PrismicToolbar = ({
 			script.dataset.repositoryName = repositoryName;
 			script.dataset.type = type;
 
-			// Disable happy-dom `<script>` evaluation during tests.
+			// Disable Happy DOM `<script>` evaluation during
+			// tests.
 			//
 			// This is a patch ONLY INCLUDED DURING TESTS. It will
 			// be pruned during code minification in non-test
@@ -51,7 +52,7 @@ export const PrismicToolbar = ({
 			//
 			// @see https://github.com/capricorn86/happy-dom/blob/02ae081e36f990c06171eda44f9d885fd9413d73/packages/happy-dom/src/nodes/html-script-element/HTMLScriptElement.ts#L191-L209
 			if (process.env.NODE_ENV === "test") {
-				// @ts-expect-error - `_evaluateScript` is a happy-dom-specific property.
+				// @ts-expect-error - `_evaluateScript` is a Happy DOM-specific property.
 				script._evaluateScript = false;
 			}
 

--- a/src/PrismicToolbar.tsx
+++ b/src/PrismicToolbar.tsx
@@ -43,6 +43,18 @@ export const PrismicToolbar = ({
 			script.dataset.repositoryName = repositoryName;
 			script.dataset.type = type;
 
+			// Disable happy-dom `<script>` evaluation during tests.
+			//
+			// This is a patch ONLY INCLUDED DURING TESTS. It will
+			// be pruned during code minification in non-test
+			// environments.
+			//
+			// @see https://github.com/capricorn86/happy-dom/blob/02ae081e36f990c06171eda44f9d885fd9413d73/packages/happy-dom/src/nodes/html-script-element/HTMLScriptElement.ts#L191-L209
+			if (process.env.NODE_ENV === "test") {
+				// @ts-expect-error - `_evaluateScript` is a happy-dom-specific property.
+				script._evaluateScript = false;
+			}
+
 			document.body.appendChild(script);
 		}
 	}, [repositoryName, type, src]);

--- a/test/PrismicToolbar.test.tsx
+++ b/test/PrismicToolbar.test.tsx
@@ -79,3 +79,21 @@ test('uses the legacy toolbar if type is set to "legacy"', (t) => {
 		t.fail("The toolbar script element was not found");
 	}
 });
+
+test("includes a Happy DOM patch to not execute scripts in test environments", (t) => {
+	const repositoryName = md5(t.title);
+
+	renderJSON(<PrismicToolbar repositoryName={repositoryName} type="legacy" />);
+
+	const script = getToolbarScript(repositoryName);
+
+	if (script instanceof HTMLScriptElement) {
+		t.is(
+			// @ts-expect-error - `_evaluateScript` is a Happy DOM-specific property.
+			script._evaluateScript,
+			false,
+		);
+	} else {
+		t.fail("The toolbar script element was not found");
+	}
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR patches `<PrismicToolbar>` to prevent the component's `<script>` element to execute in Happpy DOM environments. This is useful when using Happy DOM in tests, such as in Vitest.

The included patch will be pruned during code minification in non-test environments.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐍
