### PR TITLE
fix: throw when `<PrismicLink>`'s `field` or `document` prop value is missing required properties

### DIFF
--- a/messages/missing-link-properties.md
+++ b/messages/missing-link-properties.md
@@ -1,0 +1,55 @@
+# Missing Link properties
+
+`<PrismicLink>` requires specific properties to be included in the provided field or document to render properly. This requirement extends to [Link][link-fields], [Link to Media][link-fields], and [Content Relationship][link-fields] fields.
+
+If the required properties are missing, `<PrismicLink>` may not be able to render the link properly, if at all.
+
+**Note**: When using Prismic's [Rest API][rest-api] (the default when using `@prismicio/client`), the required fields are automatically included. When using Prismic's [GraphQL API][graphql-api], you must include these fields in your query.
+
+## Required Properties
+
+**When using the `field` prop with a Link, Link to Media, or Content Relationship field**:
+
+- `link_type` (or `_linkType` when using Prismic's [GraphQL API][graphql-api])
+- `id`
+- `url`
+- `uid` (only if your website uses a [Link Resolver][link-resolver] that uses a document's UID field)
+
+Example:
+
+```tsx
+<PrismicLink field={doc.data.linkField}>Click me</PrismicLink>
+```
+
+**When using the `document` prop with a Prismic document**:
+
+- `id`
+- `url`
+- `uid` (only if your website uses a [Link Resolver][link-resolver] that uses a document's UID field)
+
+Example:
+
+```tsx
+<PrismicLink document={doc}>Click me</PrismicLink>
+```
+
+## GraphQL Example
+
+When using Prismic's GraphQL API, Link fields must be queried with at least the following properties:
+
+```diff
+  {
+  	page(uid: "home", lang: "en-us") {
+  		linkField {
++ 			id
++ 			url
++ 			uid # only required if your website uses a Link Resolver that uses a document's UID field.
+  		}
+  	}
+  }
+```
+
+[link-fields]: https://prismic.io/docs/core-concepts/link-content-relationship
+[link-resolver]: https://prismic.io/docs/core-concepts/link-resolver-route-resolver
+[rest-api]: https://prismic.io/docs/technologies/rest-api-technical-reference
+[graphql-api]: https://prismic.io/docs/technologies/graphql

--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -3,6 +3,7 @@ import * as prismicH from "@prismicio/helpers";
 import * as prismicT from "@prismicio/types";
 
 import { __PRODUCTION__ } from "./lib/__PRODUCTION__";
+import { devMsg } from "./lib/devMsg";
 import { isInternalURL } from "./lib/isInternalURL";
 
 import { usePrismicContext } from "./usePrismicContext";
@@ -134,6 +135,37 @@ const _PrismicLink = <
 	ref: React.Ref<any>,
 ): JSX.Element | null => {
 	const context = usePrismicContext();
+
+	if (!__PRODUCTION__) {
+		if ("field" in props && props.field) {
+			if (
+				!("link_type" in props.field) ||
+				!("url" in props.field || "id" in props.field)
+			) {
+				console.error(
+					`[PrismicLink] This "field" prop value caused an error to be thrown.\n`,
+					props.field,
+				);
+				throw new Error(
+					`[PrismicLink] The provided field is missing required properties to properly render a link. The link may not render. For more details, see ${devMsg(
+						"missing-link-properties",
+					)}`,
+				);
+			}
+		} else if ("document" in props && props.document) {
+			if (!("url" in props.document || "id" in props.document)) {
+				console.error(
+					`[PrismicLink] This "document" prop value caused an error to be thrown.\n`,
+					props.document,
+				);
+				throw new Error(
+					`[PrismicLink] The provided document is missing required properties to properly render a link. The link may not render. For more details, see ${devMsg(
+						"missing-link-properties",
+					)}`,
+				);
+			}
+		}
+	}
 
 	const linkResolver = props.linkResolver || context.linkResolver;
 

--- a/test/PrismicLink.test.tsx
+++ b/test/PrismicLink.test.tsx
@@ -3,6 +3,7 @@ import * as prismicT from "@prismicio/types";
 import * as prismicH from "@prismicio/helpers";
 import * as prismicM from "@prismicio/mock";
 import * as React from "react";
+import * as sinon from "sinon";
 
 import { renderJSON } from "./__testutils__/renderJSON";
 
@@ -430,3 +431,51 @@ test("forwards ref to external component", (t) => {
 	t.is(spanRef?.tagName, "span");
 	t.is(customComponentRef?.tagName, "input");
 });
+
+test.serial(
+	"throws error if properties are missing from a given field",
+	(t) => {
+		const field = {} as prismicT.FilledLinkToDocumentField;
+
+		const consoleErrorStub = sinon.stub(console, "error");
+
+		t.throws(
+			() => {
+				renderJSON(<PrismicLink field={field} />);
+			},
+			{ message: /missing-link-properties/ },
+		);
+
+		consoleErrorStub.restore();
+
+		t.true(
+			consoleErrorStub.calledWithMatch(
+				/this "field" prop value caused an error to be thrown./i,
+			),
+		);
+	},
+);
+
+test.serial(
+	"throws error if properties are missing from a given document",
+	(t) => {
+		const document = {} as prismicT.PrismicDocument;
+
+		const consoleErrorStub = sinon.stub(console, "error");
+
+		t.throws(
+			() => {
+				renderJSON(<PrismicLink document={document} />);
+			},
+			{ message: /missing-link-properties/ },
+		);
+
+		consoleErrorStub.restore();
+
+		t.true(
+			consoleErrorStub.calledWithMatch(
+				/this "document" prop value caused an error to be thrown./i,
+			),
+		);
+	},
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a development-only error handler to the `<PrismicLink>` component.

When `<PrismicLink>` receives a `field` or `document` prop value with missing required properties, an error is thrown with a helpful message. It also logs the invalid prop value to the console before throwing for easier debugging.

See the full message in `messages/missing-link-properties.md`.

For more details, see #150.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦉
