### PR TITLE
fix: support untyped or partially typed Slices in `<SliceZone>`

### DIFF
--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -113,6 +113,37 @@ export type SliceComponentType<
 > = React.ComponentType<SliceComponentProps<TSlice, TContext>>;
 
 /**
+ * A record of Slice types mapped to a React component. The component will be
+ * rendered for each instance of its Slice.
+ *
+ * @deprecated This type is no longer used by `@prismicio/react`. Prefer using
+ *   `Record<string, SliceComponentType<any>>` instead.
+ * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
+ * @typeParam TContext - Arbitrary data made available to all Slice components.
+ */
+export type SliceZoneComponents<
+	TSlice extends SliceLike = SliceLike,
+	TContext = unknown,
+> =
+	// This is purposely not wrapped in Partial to ensure a component is provided
+	// for all Slice types. <SliceZone> will render a default component if one is
+	// not provided, but it *should* be a type error if an explicit component is
+	// missing.
+	//
+	// If a developer purposely does not want to provide a component, they can
+	// assign it to the TODOSliceComponent exported from this package. This
+	// signals to future developers that it is a placeholder and should be
+	// implemented.
+	{
+		[SliceType in ExtractSliceType<TSlice>]: SliceComponentType<
+			Extract<TSlice, SliceLike<SliceType>> extends never
+				? SliceLike
+				: Extract<TSlice, SliceLike<SliceType>>,
+			TContext
+		>;
+	};
+
+/**
  * This Slice component can be used as a reminder to provide a proper implementation.
  *
  * This is also the default React component rendered when a component mapping

--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -59,7 +59,8 @@ export type SliceLike<SliceType extends string = string> =
  *
  * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
  */
-export type SliceZoneLike<TSlice extends SliceLike> = readonly TSlice[];
+export type SliceZoneLike<TSlice extends SliceLike = SliceLike> =
+	readonly TSlice[];
 
 /**
  * React props for a component rendering content from a Prismic Slice using the
@@ -70,7 +71,8 @@ export type SliceZoneLike<TSlice extends SliceLike> = readonly TSlice[];
  *   available to all Slice components.
  */
 export type SliceComponentProps<
-	TSlice extends SliceLike = SliceLike,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TSlice extends SliceLike = any,
 	TContext = unknown,
 > = {
 	/**
@@ -105,38 +107,10 @@ export type SliceComponentProps<
  * @typeParam TContext - Arbitrary data made available to all Slice components.
  */
 export type SliceComponentType<
-	TSlice extends SliceLike = SliceLike,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TSlice extends SliceLike = any,
 	TContext = unknown,
 > = React.ComponentType<SliceComponentProps<TSlice, TContext>>;
-
-/**
- * A record of Slice types mapped to a React component. The component will be
- * rendered for each instance of its Slice.
- *
- * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
- * @typeParam TContext - Arbitrary data made available to all Slice components.
- */
-export type SliceZoneComponents<
-	TSlice extends SliceLike = SliceLike,
-	TContext = unknown,
-> =
-	// This is purposely not wrapped in Partial to ensure a component is provided
-	// for all Slice types. <SliceZone> will render a default component if one is
-	// not provided, but it *should* be a type error if an explicit component is
-	// missing.
-	//
-	// If a developer purposely does not want to provide a component, they can
-	// assign it to the TODOSliceComponent exported from this package. This
-	// signals to future developers that it is a placeholder and should be
-	// implemented.
-	{
-		[SliceType in ExtractSliceType<TSlice>]: SliceComponentType<
-			Extract<TSlice, SliceLike<SliceType>> extends never
-				? SliceLike
-				: Extract<TSlice, SliceLike<SliceType>>,
-			TContext
-		>;
-	};
 
 /**
  * This Slice component can be used as a reminder to provide a proper implementation.
@@ -169,7 +143,10 @@ export const TODOSliceComponent = __PRODUCTION__
 /**
  * Arguments for a `<SliceZone>` `resolver` function.
  */
-type SliceZoneResolverArgs<TSlice extends SliceLike = SliceLike> = {
+type SliceZoneResolverArgs<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TSlice extends SliceLike = any,
+> = {
 	/**
 	 * The Slice to resolve to a React component.
 	 */
@@ -198,11 +175,17 @@ type SliceZoneResolverArgs<TSlice extends SliceLike = SliceLike> = {
  * @returns The React component to render for a Slice.
  */
 export type SliceZoneResolver<
-	TSlice extends SliceLike = SliceLike,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TSlice extends SliceLike = any,
 	TContext = unknown,
-> = (
-	args: SliceZoneResolverArgs<TSlice>,
-) => SliceComponentType<TSlice, TContext> | undefined | null;
+> = (args: SliceZoneResolverArgs<TSlice>) =>
+	| SliceComponentType<
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			any,
+			TContext
+	  >
+	| undefined
+	| null;
 
 /**
  * React props for the `<SliceZone>` component.
@@ -210,19 +193,17 @@ export type SliceZoneResolver<
  * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
  * @typeParam TContext - Arbitrary data made available to all Slice components.
  */
-export type SliceZoneProps<
-	TSlice extends SliceLike = SliceLike,
-	TContext = unknown,
-> = {
+export type SliceZoneProps<TContext = unknown> = {
 	/**
 	 * List of Slice data from the Slice Zone.
 	 */
-	slices?: SliceZoneLike<TSlice>;
+	slices?: SliceZoneLike;
 
 	/**
 	 * A record mapping Slice types to React components.
 	 */
-	components?: SliceZoneComponents<TSlice, TContext>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	components?: Record<string, SliceComponentType<any>>;
 
 	/**
 	 * A function that determines the rendered React component for each Slice in
@@ -234,13 +215,15 @@ export type SliceZoneProps<
 	 *
 	 * @returns The React component to render for a Slice.
 	 */
-	resolver?: SliceZoneResolver<TSlice, TContext>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	resolver?: SliceZoneResolver<any, TContext>;
 
 	/**
 	 * The React component rendered if a component mapping from the `components`
 	 * prop cannot be found.
 	 */
-	defaultComponent?: SliceComponentType<TSlice, TContext>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	defaultComponent?: SliceComponentType<any, TContext>;
 
 	/**
 	 * Arbitrary data made available to all Slice components.
@@ -263,19 +246,19 @@ export type SliceZoneProps<
  *
  * @see Learn about Prismic Slices and Slice Zones {@link https://prismic.io/docs/core-concepts/slices}
  */
-export const SliceZone = <TSlice extends SliceLike, TContext>({
+export const SliceZone = <TContext,>({
 	slices = [],
-	components = {} as SliceZoneComponents<TSlice, TContext>,
+	components = {},
 	resolver,
 	defaultComponent = TODOSliceComponent,
 	context = {} as TContext,
-}: SliceZoneProps<TSlice, TContext>): JSX.Element => {
+}: SliceZoneProps<TContext>): JSX.Element => {
 	const renderedSlices = React.useMemo(() => {
 		return slices.map((slice, index) => {
 			const type = "slice_type" in slice ? slice.slice_type : slice.type;
 
-			let Comp = (components[type as keyof typeof components] ||
-				defaultComponent) as SliceComponentType<TSlice, TContext>;
+			let Comp =
+				components[type as keyof typeof components] || defaultComponent;
 
 			// TODO: Remove `resolver` in v3 in favor of `components`.
 			if (resolver) {
@@ -286,7 +269,7 @@ export const SliceZone = <TSlice extends SliceLike, TContext>({
 				});
 
 				if (resolvedComp) {
-					Comp = resolvedComp;
+					Comp = resolvedComp as typeof Comp;
 				}
 			}
 

--- a/test/SliceZone.test.tsx
+++ b/test/SliceZone.test.tsx
@@ -126,9 +126,9 @@ test("renders TODO component if component mapping is missing", (t) => {
 	const actual = renderJSON(
 		<SliceZone
 			slices={slices}
-			// @ts-expect-error - We are leaving `bar` out of the test on purpose.
 			components={{
 				foo: (props) => <StringifySliceComponent id="foo" {...props} />,
+				// NOTE: The `bar` component is purposely left out of this test.
 				// bar: (props) => <StringifySliceComponent id="bar" {...props} />,
 			}}
 		/>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR changes `<SliceZone>` to accept untyped or partially typed Slices. The changes affect both the provided Slices (the `slices` prop) and components (the `components` prop).

It effectively removes any type checking between the `slices` and `components` props.

It also defaults Slice components' `slice` prop to `any` rather than `SliceLike`. This was done to support Prismic's Rest API and GraphQL API with the same set of types.

Developers can still provide types to their API responses via `@prismicio/client`'s type parameters and Slice components via `@prismicio/react`'s `SliceComponentProps`. This PR does not include breaking changes.

While these changes may seem like a step backwards, it broadens the library's support to include projects with insufficient type data. Today, projects with insufficient types is common. This can happen when Slice components are properly typed, but the API data is not. This is even the case in Prismic-provided integrations like [Slice Simulator](https://github.com/prismicio/slice-simulator).

Rather than force developers to hand-type their projects, the library has been updated to gracefully support untyped or partially typed data and components.

For more details on what prompted this change, see https://github.com/prismicio/prismic-types/issues/34.

---

### Component Type Examples

`<SliceZone>` will accept any of these typed components.

**Fully typing a Slice component for Prismic's Rest API**:

```tsx
import { SliceComponentProps } from "@prismicio/react";
import * as prismicT from "@prismicio/types";

type ImageSlice = prismicT.SharedSlice<
  "image",
  prismicT.SharedSliceVariation<
    "default",
    {
      image: prismicT.ImageField;
    },
    never
  >
>;

const Image = ({ slice }: SliceComponentProps<ImageSlice>) => {
  return <section>{/* implementation */}</section>;
};
```

**Fully typing a Slice component for Prismic's GraphQL API using a generated type (e.g. from [GraphQL Code Generator](https://www.graphql-code-generator.com/))**:

```tsx
import { SliceComponentProps } from "@prismicio/react";

// A type generated from a tool like GraphQL Code Generator
import { ImageSlice } from "../types.generated";

const Image = ({ slice }: SliceComponentProps<ImageSlice>) => {
  return <section>{/* implementation */}</section>;
};
```

**Partially typing a Slice component (restricted to Prismic's Rest API)**:

```tsx
import { SliceComponentProps, SliceLikeRestV2 } from "@prismicio/react";

const Image = ({ slice }: SliceComponentProps<SliceLikeRestV2>) => {
  return <section>{/* implementation */}</section>;
};
```

**Partially typing a Slice component (restricted to Prismic's GraphQL API)**:

```tsx
import { SliceComponentProps, SliceLikeGraphQL } from "@prismicio/react";

const Image = ({ slice }: SliceComponentProps<SliceLikeGraphQL>) => {
  return <section>{/* implementation */}</section>;
};
```

**Partially typing a Slice component (any API)**:

```tsx
import { SliceComponentProps } from "@prismicio/react";

// `slice` is typed as `any`
const Image = ({ slice }: SliceComponentProps) => {
  return <section>{/* implementation */}</section>;
};
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦢
