### PR TITLE
fix: prefer warning over throwing when `<PrismicLink>` is given an invalid prop in development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.4.1",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prismicio/helpers": "^2.3.0",
+				"@prismicio/helpers": "^2.3.1",
 				"@prismicio/richtext": "^2.0.1"
 			},
 			"devDependencies": {
@@ -720,9 +720,9 @@
 			}
 		},
 		"node_modules/@prismicio/helpers": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.0.tgz",
-			"integrity": "sha512-/3YJ3F7bN56Pn9y2B4a3t0y4QD0zVPqaHf0Rzd5jCA7Bf0wi3oQ35KHGmP3DrYzz16aQNOZgQy/IO/80QsOYTg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.1.tgz",
+			"integrity": "sha512-J37WpIUINZ0wT3a2h4fc9ATZqjmQjziPwjETG7QLYEVULpQXsWbgM+C6aoOqdlRwCbZ3Wfhel26+++ZaqOX/0Q==",
 			"dependencies": {
 				"@prismicio/richtext": "^2.0.1",
 				"@prismicio/types": "^0.1.27",
@@ -11833,9 +11833,9 @@
 			}
 		},
 		"@prismicio/helpers": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.0.tgz",
-			"integrity": "sha512-/3YJ3F7bN56Pn9y2B4a3t0y4QD0zVPqaHf0Rzd5jCA7Bf0wi3oQ35KHGmP3DrYzz16aQNOZgQy/IO/80QsOYTg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.1.tgz",
+			"integrity": "sha512-J37WpIUINZ0wT3a2h4fc9ATZqjmQjziPwjETG7QLYEVULpQXsWbgM+C6aoOqdlRwCbZ3Wfhel26+++ZaqOX/0Q==",
 			"requires": {
 				"@prismicio/richtext": "^2.0.1",
 				"@prismicio/types": "^0.1.27",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"unit": "nyc --reporter=lcovonly --reporter=text --exclude-after-remap=false ava"
 	},
 	"dependencies": {
-		"@prismicio/helpers": "^2.3.0",
+		"@prismicio/helpers": "^2.3.1",
 		"@prismicio/richtext": "^2.0.1"
 	},
 	"devDependencies": {

--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -138,30 +138,36 @@ const _PrismicLink = <
 
 	if (!__PRODUCTION__) {
 		if ("field" in props && props.field) {
-			if (
-				!("link_type" in props.field) ||
-				!("url" in props.field || "id" in props.field)
-			) {
+			if (!props.field.link_type) {
 				console.error(
 					`[PrismicLink] This "field" prop value caused an error to be thrown.\n`,
 					props.field,
 				);
 				throw new Error(
-					`[PrismicLink] The provided field is missing required properties to properly render a link. The link may not render. For more details, see ${devMsg(
+					`[PrismicLink] The provided field is missing required properties to properly render a link. The link will not render. For more details, see ${devMsg(
 						"missing-link-properties",
 					)}`,
+				);
+			} else if (
+				!(
+					prismicH.isFilled.link(props.field) &&
+					("url" in props.field || "id" in props.field)
+				)
+			) {
+				console.warn(
+					`[PrismicLink] The provided field is missing required properties to properly render a link. The link may not render correctly. For more details, see ${devMsg(
+						"missing-link-properties",
+					)}`,
+					props.field,
 				);
 			}
 		} else if ("document" in props && props.document) {
 			if (!("url" in props.document || "id" in props.document)) {
-				console.error(
-					`[PrismicLink] This "document" prop value caused an error to be thrown.\n`,
-					props.document,
-				);
-				throw new Error(
-					`[PrismicLink] The provided document is missing required properties to properly render a link. The link may not render. For more details, see ${devMsg(
+				console.warn(
+					`[PrismicLink] The provided document is missing required properties to properly render a link. The link may not render correctly. For more details, see ${devMsg(
 						"missing-link-properties",
 					)}`,
+					props.document,
 				);
 			}
 		}

--- a/test/PrismicLink.test.tsx
+++ b/test/PrismicLink.test.tsx
@@ -433,7 +433,7 @@ test("forwards ref to external component", (t) => {
 });
 
 test.serial(
-	"throws error if properties are missing from a given field",
+	"throws error if `link_type` is missing from a given field",
 	(t) => {
 		const field = {} as prismicT.FilledLinkToDocumentField;
 
@@ -456,26 +456,41 @@ test.serial(
 	},
 );
 
-test.serial(
-	"throws error if properties are missing from a given document",
-	(t) => {
-		const document = {} as prismicT.PrismicDocument;
+test.serial("warns if properties are missing from a given field", (t) => {
+	const field = { link_type: prismicT.LinkType.Web };
 
-		const consoleErrorStub = sinon.stub(console, "error");
+	const consoleWarnStub = sinon.stub(console, "warn");
 
-		t.throws(
-			() => {
-				renderJSON(<PrismicLink document={document} />);
-			},
-			{ message: /missing-link-properties/ },
-		);
+	renderJSON(<PrismicLink field={field} />);
 
-		consoleErrorStub.restore();
+	consoleWarnStub.restore();
 
-		t.true(
-			consoleErrorStub.calledWithMatch(
-				/this "document" prop value caused an error to be thrown./i,
-			),
-		);
-	},
-);
+	t.true(consoleWarnStub.calledWithMatch("missing-link-properties"));
+});
+
+test.serial("does not warn if given field is empty", (t) => {
+	const field = prismicM.value.link({
+		seed: t.title,
+		state: "empty",
+	});
+
+	const consoleWarnStub = sinon.stub(console, "warn");
+
+	renderJSON(<PrismicLink field={field} />);
+
+	consoleWarnStub.restore();
+
+	t.true(consoleWarnStub.calledWithMatch("missing-link-properties"));
+});
+
+test.serial("warns if properties are missing from a given document", (t) => {
+	const document = {} as prismicT.PrismicDocument;
+
+	const consoleWarnStub = sinon.stub(console, "warn");
+
+	renderJSON(<PrismicLink document={document} />);
+
+	consoleWarnStub.restore();
+
+	t.true(consoleWarnStub.calledWithMatch("missing-link-properties"));
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR changes `<PrismicLink>`'s development-only behavior to warn rather than throw when given an invalid Link field or Prismic document (in most cases; see the note below).

In addition to reducing the severity of an invalid field or document, this PR also fixes a bug where a valid unfilled Link field (i.e. a field that a content writer did not fill in) was treated as invalid. Unfilled Link fields are now treated as valid.

**Note**: `<PrismicLink>` will still throw if a `link_type` property is missing from the provided `field` prop value. `link_type` is required to detect the type of link and is populated even for unfilled Link fields.

(Thanks to @kb1995 for [discovering this bug](https://github.com/prismicio/prismic-react/issues/150#issuecomment-1147327993)!)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐱
