### PR TITLE
fix(PrismicLink): do not warn about missing field properties if the Link field is empty

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -149,10 +149,8 @@ const _PrismicLink = <
 					)}`,
 				);
 			} else if (
-				!(
-					prismicH.isFilled.link(props.field) &&
-					("url" in props.field || "id" in props.field)
-				)
+				Object.keys(props.field).length > 1 &&
+				!("url" in props.field || "uid" in props.field || "id" in props.field)
 			) {
 				console.warn(
 					`[PrismicLink] The provided field is missing required properties to properly render a link. The link may not render correctly. For more details, see ${devMsg(

--- a/test/PrismicLink.test.tsx
+++ b/test/PrismicLink.test.tsx
@@ -457,7 +457,7 @@ test.serial(
 );
 
 test.serial("warns if properties are missing from a given field", (t) => {
-	const field = { link_type: prismicT.LinkType.Web };
+	const field = { link_type: prismicT.LinkType.Web, target: "_blank" };
 
 	const consoleWarnStub = sinon.stub(console, "warn");
 
@@ -480,7 +480,7 @@ test.serial("does not warn if given field is empty", (t) => {
 
 	consoleWarnStub.restore();
 
-	t.true(consoleWarnStub.calledWithMatch("missing-link-properties"));
+	t.false(consoleWarnStub.called);
 });
 
 test.serial("warns if properties are missing from a given document", (t) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug in `<PrismicLink>` where it logged a console warning about missing Link field properties when given an empty Link field value. Empty link values are valid and should not trigger the warning.

The issue was unknown because the test to check this exact case was written incorrectly ([see the fix](https://github.com/prismicio/prismic-react/pull/163/files#diff-fdb4f3665170c51342618d4178b9cfba515f44fb94272c3df92a9221cd174360L483-R483)).

Fixes #161

Thanks to @ReeceM for uncovering the issue!

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐈
