### PR TITLE
fix(PrismicLink): only set `target="_blank"` when "Open in new tab" is checked

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -190,7 +190,6 @@ const _PrismicLink = <
 			props.field &&
 			"target" in props.field &&
 			props.field.target) ||
-		(!isInternal && "_blank") ||
 		undefined;
 
 	const rel =

--- a/test/PrismicLink.test.tsx
+++ b/test/PrismicLink.test.tsx
@@ -217,7 +217,7 @@ test("allow overriding default target", (t) => {
 	t.deepEqual(actual, expected);
 });
 
-test("if manually given _blank to target, use rel'noopener norefferer", (t) => {
+test('if manually given _blank to target, use rel="noopener norefferer"', (t) => {
 	const field: prismicT.FilledLinkToWebField = {
 		url: "/url",
 		link_type: prismicT.LinkType.Web,
@@ -231,10 +231,10 @@ test("if manually given _blank to target, use rel'noopener norefferer", (t) => {
 	t.deepEqual(actual, expected);
 });
 
-test('if target is not explicitly provided and the URL is external, use target="_blank" and rel="noopener noreferrer"', (t) => {
+test("if target is not provided and the URL is external, target is not set", (t) => {
 	const actual = renderJSON(<PrismicLink href="https://example.com" />);
 	const expected = renderJSON(
-		<a href="https://example.com" target="_blank" rel="noopener noreferrer" />,
+		<a href="https://example.com" target={undefined} rel={undefined} />,
 	);
 
 	t.deepEqual(actual, expected);
@@ -289,7 +289,7 @@ test("if URL is internal and internalComponent is given to the provider and the 
 test("if URL is external and no externalComponent is given, render an <a>", (t) => {
 	const actual = renderJSON(<PrismicLink href="https://example.com" />);
 	const expected = renderJSON(
-		<a href="https://example.com" rel="noopener noreferrer" target="_blank" />,
+		<a href="https://example.com" target={undefined} rel={undefined} />,
 	);
 
 	t.deepEqual(actual, expected);
@@ -299,13 +299,7 @@ test("if URL is external and externalComponent is given, render externalComponen
 	const actual = renderJSON(
 		<PrismicLink href="https://example.com" externalComponent={Link} />,
 	);
-	const expected = renderJSON(
-		<Link
-			href="https://example.com"
-			rel="noopener noreferrer"
-			target="_blank"
-		/>,
-	);
+	const expected = renderJSON(<Link href="https://example.com" />);
 
 	t.deepEqual(actual, expected);
 });
@@ -316,13 +310,7 @@ test("if URL is external and externalComponent is given to the provider, render 
 			<PrismicLink href="https://example.com" />
 		</PrismicProvider>,
 	);
-	const expected = renderJSON(
-		<Link
-			href="https://example.com"
-			rel="noopener noreferrer"
-			target="_blank"
-		/>,
-	);
+	const expected = renderJSON(<Link href="https://example.com" />);
 
 	t.deepEqual(actual, expected);
 });
@@ -333,13 +321,7 @@ test("if URL is external and externalComponent is given to the provider and the 
 			<PrismicLink href="https://example.com" externalComponent={Link} />
 		</PrismicProvider>,
 	);
-	const expected = renderJSON(
-		<Link
-			href="https://example.com"
-			rel="noopener noreferrer"
-			target="_blank"
-		/>,
-	);
+	const expected = renderJSON(<Link href="https://example.com" />);
 
 	t.deepEqual(actual, expected);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR changes `<PrismicLink>` such that `target="_blank"` is only automatically set when a Link field's "Open in new tab" checkbox is checked.

Before this PR, `<PrismicLink>` would set `target="_blank"` when "Open in new tab" was checked **or** when the URL was external (i.e. started with `https://`).

Automatically opening external URLs in new windows was originally introduced as a convenience. However, this meant the "Open in new tab" checkbox was ignored in some cases; if the checkbox was purposely unchecked, the link would still open in a new window. This is considered a bug.

`rel="noopener noreferrer"` will continue to be set automatically if `target="_blank"` is set.

Fixes #171

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐛
