### PR TITLE
fix(SliceZone): restore `resolver` prop

### DIFF
--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -1,6 +1,19 @@
 import * as React from "react";
 import * as prismic from "@prismicio/client";
 
+import { pascalCase, PascalCase } from "./lib/pascalCase";
+
+/**
+ * Returns the type of a `SliceLike` type.
+ *
+ * @typeParam Slice - The Slice from which the type will be extracted.
+ */
+type ExtractSliceType<Slice extends SliceLike> = Slice extends SliceLikeRestV2
+	? Slice["slice_type"]
+	: Slice extends SliceLikeGraphQL
+	? Slice["type"]
+	: never;
+
 /**
  * The minimum required properties to represent a Prismic Slice from the Prismic
  * Rest API V2 for the `<SliceZone>` component.
@@ -102,6 +115,37 @@ export type SliceComponentType<
 > = React.ComponentType<SliceComponentProps<TSlice, TContext>>;
 
 /**
+ * A record of Slice types mapped to a React component. The component will be
+ * rendered for each instance of its Slice.
+ *
+ * @deprecated This type is no longer used by `@prismicio/react`. Prefer using
+ *   `Record<string, SliceComponentType<any>>` instead.
+ * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
+ * @typeParam TContext - Arbitrary data made available to all Slice components.
+ */
+export type SliceZoneComponents<
+	TSlice extends SliceLike = SliceLike,
+	TContext = unknown,
+> =
+	// This is purposely not wrapped in Partial to ensure a component is provided
+	// for all Slice types. <SliceZone> will render a default component if one is
+	// not provided, but it *should* be a type error if an explicit component is
+	// missing.
+	//
+	// If a developer purposely does not want to provide a component, they can
+	// assign it to the TODOSliceComponent exported from this package. This
+	// signals to future developers that it is a placeholder and should be
+	// implemented.
+	{
+		[SliceType in ExtractSliceType<TSlice>]: SliceComponentType<
+			Extract<TSlice, SliceLike<SliceType>> extends never
+				? SliceLike
+				: Extract<TSlice, SliceLike<SliceType>>,
+			TContext
+		>;
+	};
+
+/**
  * This Slice component can be used as a reminder to provide a proper
  * implementation.
  *
@@ -131,6 +175,54 @@ export const TODOSliceComponent = <TSlice extends SliceLike, TContext>({
 };
 
 /**
+ * Arguments for a `<SliceZone>` `resolver` function.
+ */
+type SliceZoneResolverArgs<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TSlice extends SliceLike = any,
+> = {
+	/**
+	 * The Slice to resolve to a React component.
+	 */
+	slice: TSlice;
+
+	/**
+	 * The name of the Slice.
+	 */
+	sliceName: PascalCase<ExtractSliceType<TSlice>>;
+
+	/**
+	 * The index of the Slice in the Slice Zone.
+	 */
+	i: number;
+};
+
+/**
+ * A function that determines the rendered React component for each Slice in the
+ * Slice Zone. If a nullish value is returned, the component will fallback to
+ * the `components` or `defaultComponent` props to determine the rendered
+ * component.
+ *
+ * @deprecated Use the `components` prop instead.
+ *
+ * @param args - Arguments for the resolver function.
+ *
+ * @returns The React component to render for a Slice.
+ */
+export type SliceZoneResolver<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TSlice extends SliceLike = any,
+	TContext = unknown,
+> = (args: SliceZoneResolverArgs<TSlice>) =>
+	| SliceComponentType<
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			any,
+			TContext
+	  >
+	| undefined
+	| null;
+
+/**
  * React props for the `<SliceZone>` component.
  *
  * @typeParam TSlice - The type(s) of a Slice in the Slice Zone.
@@ -147,6 +239,19 @@ export type SliceZoneProps<TContext = unknown> = {
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	components?: Record<string, SliceComponentType<any, TContext>>;
+
+	/**
+	 * A function that determines the rendered React component for each Slice in
+	 * the Slice Zone.
+	 *
+	 * @deprecated Use the `components` prop instead.
+	 *
+	 * @param args - Arguments for the resolver function.
+	 *
+	 * @returns The React component to render for a Slice.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	resolver?: SliceZoneResolver<any, TContext>;
 
 	/**
 	 * The React component rendered if a component mapping from the `components`
@@ -179,6 +284,7 @@ export type SliceZoneProps<TContext = unknown> = {
 export const SliceZone = <TContext,>({
 	slices = [],
 	components = {},
+	resolver,
 	defaultComponent = TODOSliceComponent,
 	context = {} as TContext,
 }: SliceZoneProps<TContext>): JSX.Element => {
@@ -186,8 +292,21 @@ export const SliceZone = <TContext,>({
 		return slices.map((slice, index) => {
 			const type = "slice_type" in slice ? slice.slice_type : slice.type;
 
-			const Comp =
+			let Comp =
 				components[type as keyof typeof components] || defaultComponent;
+
+			// TODO: Remove `resolver` in v3 in favor of `components`.
+			if (resolver) {
+				const resolvedComp = resolver({
+					slice,
+					sliceName: pascalCase(type),
+					i: index,
+				});
+
+				if (resolvedComp) {
+					Comp = resolvedComp as typeof Comp;
+				}
+			}
 
 			const key =
 				"id" in slice && slice.id
@@ -204,7 +323,7 @@ export const SliceZone = <TContext,>({
 				/>
 			);
 		});
-	}, [components, context, defaultComponent, slices]);
+	}, [components, context, defaultComponent, slices, resolver]);
 
 	return <>{renderedSlices}</>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,10 @@ export { SliceZone, TODOSliceComponent } from "./SliceZone";
 export type {
 	SliceComponentProps,
 	SliceComponentType,
-	SliceLikeRestV2,
-	SliceLikeGraphQL,
 	SliceLike,
+	SliceLikeGraphQL,
+	SliceLikeRestV2,
+	SliceZoneComponents,
 	SliceZoneLike,
 	SliceZoneProps,
 } from "./SliceZone";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR restores the `resolver` prop in `<SliceZone>`.

This prop is deprecated and should not be used. It will be removed in the next major version. It was mistakenly removed in a minor release (v2.6.0).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
