### PR TITLE
fix(PrismicImage): allow removing Imgix params in React Server Components using `null`

### DIFF
--- a/test/PrismicImage.test.tsx
+++ b/test/PrismicImage.test.tsx
@@ -323,3 +323,33 @@ it("supports imgix parameters", async (ctx) => {
 
 	expect(actual).toStrictEqual(expected);
 });
+
+it("allows removing existing Imgix params via the imgixParams prop", async (ctx) => {
+	const field = ctx.mock.value.image({
+		model: ctx.mock.model.image(),
+	});
+	const fieldURL = new URL(field.url);
+	fieldURL.searchParams.set("auto", "compress,format");
+	fieldURL.searchParams.set("sat", "-100");
+	fieldURL.searchParams.set("ar", "1:2");
+	field.url = fieldURL.toString();
+
+	const img = renderJSON(
+		<PrismicImage
+			field={field}
+			imgixParams={{
+				auto: undefined,
+				// React Server Components removes `undefined`
+				// from objects, so we also support `null` as an
+				// explicit value to remove a param.
+				sat: null,
+			}}
+		/>,
+	);
+
+	const src = new URL(img?.props.src);
+
+	expect(src.searchParams.get("auto")).toBe(null);
+	expect(src.searchParams.get("sat")).toBe(null);
+	expect(src.searchParams.get("ar")).toBe("1:2");
+});

--- a/test/__testutils__/renderJSON.ts
+++ b/test/__testutils__/renderJSON.ts
@@ -11,7 +11,7 @@ import * as renderer from "react-test-renderer";
 export const renderJSON = (
 	element: React.ReactElement,
 	options?: renderer.TestRendererOptions,
-): renderer.ReactTestRendererJSON | renderer.ReactTestRendererJSON[] | null => {
+): renderer.ReactTestRendererJSON | null => {
 	let root: renderer.ReactTestRenderer;
 
 	renderer.act(() => {
@@ -19,5 +19,5 @@ export const renderJSON = (
 	});
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	return root!.toJSON();
+	return root!.toJSON() as renderer.ReactTestRendererJSON;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a case where `<PrismicImage>` would not remove Imgix parameters when used in React Server Components (RSC).

RSCs serialize prop values before sending to Client Compomnents like `<PrismicImage>`. During this serialization, `undefined` values are removed from objects, which `<PrismicImage>`'s underlying Imgix param library, `imgix-url-builder`, relies on to remove parameters.

To fix this, `imgixParams` now accepts `null` in place of `undefined`.

**`null` should be used to remove parameters when `<PrismicImage>` is used in Server Components.**

```tsx
// In a Server Component
<PrismicImage
  field={myImageField}
  imgixParams={{
    auto: null, // undefined will not work
  }}
/>
```

```tsx
// In a Client Component
<PrismicImage
  field={myImageField}
  imgixParams={{
    auto: undefined, // null can also be used
  }}
/>
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
