### PR TITLE
fix: resolve TypeScript build error in projects using `--isolatedModules`

### DIFF
--- a/src/PrismicLink.tsx
+++ b/src/PrismicLink.tsx
@@ -11,7 +11,7 @@ import {
 
 import { usePrismicContext } from "./usePrismicContext";
 
-export { LinkProps, PrismicLinkProps };
+export type { LinkProps, PrismicLinkProps };
 
 export const PrismicLink = React.forwardRef(function PrismicLink<
 	InternalComponentProps = React.ComponentProps<typeof defaultComponent>,

--- a/src/PrismicRichText.tsx
+++ b/src/PrismicRichText.tsx
@@ -10,7 +10,7 @@ import {
 
 import { usePrismicContext } from "./usePrismicContext";
 
-export { PrismicRichTextProps };
+export type { PrismicRichTextProps };
 
 export const PrismicRichText = function PrismicRichText<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Fixing issue when using Next.JS  with Typescript with the mandatory `--isolatedModule` set to `true`. This requires having all type exports as `export type`. The change also keeps the type export consistent with the `index.ts` type exports.
Fixes: `Type error: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.`

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🚘