### PR TITLE
fix: Specifies type of package as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 	"module": "./dist/index.js",
 	"react-native": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"files": [
+  	"type": "module",
+  	"files": [
 		"dist",
 		"src"
 	],


### PR DESCRIPTION
In the process of changing framework from Gatsby to Astro, I have stumbled on a build error while using React SSR with astro using this package.

```
22:57:28 [ERROR] Cannot use import statement outside a module
  Stack trace:
    at internalCompileFunction (node:internal/vm:73:18)
    at Module._compile (node:internal/modules/cjs/loader:1220:27)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
```

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This change involves specifying the type of the package to module, wich seems to be the intended type.

Linking this package locally and setting a component using the prismicio to render with SSR works great, for example:

```tsx
import {PrismicImage} from "@prismicio/react";

const serializer = {
    image: ({node}) => renderToString(<PrismicImage field={node} />)
}
```

It also keep working for clientside only rendered components.

Resolves: #193 

## Checklist:


- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

Thanks for your time :)

Instead of an animal or car picture, here is a smiling EN57
![image](https://github.com/prismicio/prismic-react/assets/19529767/5164c7ae-93c0-4354-b723-68338adecb72)
Pic by MOs810 on Wikimedia
