### PR TITLE
fix: `<TodoSliceComponent />` compat with Slice Mapper

### DIFF
--- a/src/SliceZone.tsx
+++ b/src/SliceZone.tsx
@@ -247,9 +247,11 @@ export type SliceZoneProps<TContext = unknown> = {
  * This is also the default React component rendered when a component mapping
  * cannot be found in `<SliceZone>`.
  */
-export const TODOSliceComponent = <TSlice extends SliceLike, TContext>({
+export const TODOSliceComponent = <TSlice extends SliceLike>({
 	slice,
-}: SliceComponentProps<TSlice, TContext>): JSX.Element | null => {
+}: {
+	slice: TSlice;
+}): JSX.Element | null => {
 	if (
 		typeof process !== "undefined" &&
 		process.env.NODE_ENV === "development"
@@ -291,7 +293,7 @@ export function SliceZone<TContext>({
 	slices = [],
 	components = {},
 	resolver,
-	defaultComponent = TODOSliceComponent,
+	defaultComponent,
 	context = {} as TContext,
 }: SliceZoneProps<TContext>) {
 	// TODO: Remove in v3 when the `resolver` prop is removed.
@@ -326,20 +328,24 @@ export function SliceZone<TContext>({
 				? slice.id
 				: `${index}-${JSON.stringify(slice)}`;
 
-		if (slice.__mapped) {
-			const { __mapped, ...mappedProps } = slice;
+		if (Comp) {
+			if (slice.__mapped) {
+				const { __mapped, ...mappedProps } = slice;
 
-			return <Comp key={key} {...mappedProps} />;
+				return <Comp key={key} {...mappedProps} />;
+			} else {
+				return (
+					<Comp
+						key={key}
+						slice={slice}
+						index={index}
+						slices={slices}
+						context={context}
+					/>
+				);
+			}
 		} else {
-			return (
-				<Comp
-					key={key}
-					slice={slice}
-					index={index}
-					slices={slices}
-					context={context}
-				/>
-			);
+			return <TODOSliceComponent key={key} slice={slice} />;
 		}
 	});
 

--- a/test/SliceZone.test.tsx
+++ b/test/SliceZone.test.tsx
@@ -133,7 +133,9 @@ it("renders TODO component if component mapping is missing", (ctx) => {
 		ctx.mock.value.slice(),
 		// Testing a GraphQL Slice
 		{ type: "baz" },
-	];
+		// Testing a mapped Slice
+		{ __mapped: true, id: "4", slice_type: "qux", abc: "123" },
+	] as const;
 	(slices[0] as Slice).slice_type = "foo";
 	(slices[1] as Slice).slice_type = "bar";
 
@@ -156,18 +158,9 @@ it("renders TODO component if component mapping is missing", (ctx) => {
 				slices={slices}
 				context={{}}
 			/>
-			<TODOSliceComponent
-				slice={slices[1]}
-				index={0}
-				slices={slices}
-				context={{}}
-			/>
-			<TODOSliceComponent
-				slice={slices[2]}
-				index={0}
-				slices={slices}
-				context={{}}
-			/>
+			<TODOSliceComponent slice={slices[1]} />
+			<TODOSliceComponent slice={slices[2]} />
+			<TODOSliceComponent slice={slices[3]} />
 		</>,
 	);
 
@@ -179,6 +172,10 @@ it("renders TODO component if component mapping is missing", (ctx) => {
 	expect(consoleWarnSpy).toHaveBeenCalledWith(
 		expect.stringMatching(/could not find a component/i),
 		slices[2],
+	);
+	expect(consoleWarnSpy).toHaveBeenCalledWith(
+		expect.stringMatching(/could not find a component/i),
+		slices[3],
 	);
 
 	consoleWarnSpy.mockRestore();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Mapped slices would cause the `<TODOSliceComponent />` component to throw because of a different interface used by mapped slices (slice type being top level instead of nested under the `slice` property).

This standardizes the props given to `<TODOSliceComponent />` so everything keeps working smoothly based on our Svelte implementation: https://github.com/prismicio/prismic-svelte/blob/master/src/SliceZone/SliceZone.svelte#L118-L128

I first explored adapting the `<TODOSliceComponent />` to support different interfaces instead, but it resulted in messier code in my opinion: https://github.com/prismicio/prismic-vue/blob/95d5771b51dc45df5bd6663178afceae8942dc4c/src/components/SliceZone.ts#L263-L280 (hence the sister PR for Vue: https://github.com/prismicio/prismic-vue/pull/70)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
