### PR TITLE
fix(helpers): add missing `dir` attribute for right-to-left languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 			},
 			"devDependencies": {
 				"@prismicio/client": "^7.11.0",
-				"@prismicio/mock": "0.3.8-alpha.2",
+				"@prismicio/mock": "0.4.0",
 				"@size-limit/preset-small-lib": "^8.2.4",
 				"@testing-library/react": "^14.0.0",
 				"@types/node-fetch": "^3.0.3",
@@ -1169,9 +1169,9 @@
 			}
 		},
 		"node_modules/@prismicio/mock": {
-			"version": "0.3.8-alpha.2",
-			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.3.8-alpha.2.tgz",
-			"integrity": "sha512-LtLeIp88Y1vvQzyWCcK0k0aYdoexh7Yep31WeiUmZXnZ8p91sliw9HXZDEHqnKX2SjZx6sSv+P7oBVcq6IsH+g==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.4.0.tgz",
+			"integrity": "sha512-CtTEbp/3NOdyP2StC8lGBAE4IwPJOegWEYKSEAQTjp+6BgcGcqUHr1iVBwKd3EFKVoBWA+8tJNP0m0/AFPOuNw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -9610,9 +9610,9 @@
 			}
 		},
 		"@prismicio/mock": {
-			"version": "0.3.8-alpha.2",
-			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.3.8-alpha.2.tgz",
-			"integrity": "sha512-LtLeIp88Y1vvQzyWCcK0k0aYdoexh7Yep31WeiUmZXnZ8p91sliw9HXZDEHqnKX2SjZx6sSv+P7oBVcq6IsH+g==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.4.0.tgz",
+			"integrity": "sha512-CtTEbp/3NOdyP2StC8lGBAE4IwPJOegWEYKSEAQTjp+6BgcGcqUHr1iVBwKd3EFKVoBWA+8tJNP0m0/AFPOuNw==",
 			"dev": true,
 			"requires": {
 				"change-case": "^5.4.4"

--- a/src/react-server/PrismicRichText.tsx
+++ b/src/react-server/PrismicRichText.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as prismic from "@prismicio/client";
 import * as prismicR from "@prismicio/richtext";
+import * as prismicT from "@prismicio/types";
 
 import { JSXFunctionSerializer, JSXMapSerializer } from "../types";
 import { LinkProps, PrismicLink } from "./PrismicLink";
@@ -86,6 +87,12 @@ type CreateDefaultSerializerArgs<
 	externalLinkComponent?: React.ComponentType<LinkProps>;
 };
 
+const getDir = (node: prismicT.RTAnyNode): "rtl" | undefined => {
+	if ("direction" in node && node.direction === "rtl") {
+		return "rtl";
+	}
+};
+
 const createDefaultSerializer = <
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	LinkResolverFunction extends prismic.LinkResolverFunction<any>,
@@ -93,18 +100,54 @@ const createDefaultSerializer = <
 	args: CreateDefaultSerializerArgs<LinkResolverFunction>,
 ): JSXFunctionSerializer =>
 	prismicR.wrapMapSerializer({
-		heading1: ({ children, key }) => <h1 key={key}>{children}</h1>,
-		heading2: ({ children, key }) => <h2 key={key}>{children}</h2>,
-		heading3: ({ children, key }) => <h3 key={key}>{children}</h3>,
-		heading4: ({ children, key }) => <h4 key={key}>{children}</h4>,
-		heading5: ({ children, key }) => <h5 key={key}>{children}</h5>,
-		heading6: ({ children, key }) => <h6 key={key}>{children}</h6>,
-		paragraph: ({ children, key }) => <p key={key}>{children}</p>,
+		heading1: ({ node, children, key }) => (
+			<h1 key={key} dir={getDir(node)}>
+				{children}
+			</h1>
+		),
+		heading2: ({ node, children, key }) => (
+			<h2 key={key} dir={getDir(node)}>
+				{children}
+			</h2>
+		),
+		heading3: ({ node, children, key }) => (
+			<h3 key={key} dir={getDir(node)}>
+				{children}
+			</h3>
+		),
+		heading4: ({ node, children, key }) => (
+			<h4 key={key} dir={getDir(node)}>
+				{children}
+			</h4>
+		),
+		heading5: ({ node, children, key }) => (
+			<h5 key={key} dir={getDir(node)}>
+				{children}
+			</h5>
+		),
+		heading6: ({ node, children, key }) => (
+			<h6 key={key} dir={getDir(node)}>
+				{children}
+			</h6>
+		),
+		paragraph: ({ node, children, key }) => (
+			<p key={key} dir={getDir(node)}>
+				{children}
+			</p>
+		),
 		preformatted: ({ node, key }) => <pre key={key}>{node.text}</pre>,
 		strong: ({ children, key }) => <strong key={key}>{children}</strong>,
 		em: ({ children, key }) => <em key={key}>{children}</em>,
-		listItem: ({ children, key }) => <li key={key}>{children}</li>,
-		oListItem: ({ children, key }) => <li key={key}>{children}</li>,
+		listItem: ({ node, children, key }) => (
+			<li key={key} dir={getDir(node)}>
+				{children}
+			</li>
+		),
+		oListItem: ({ node, children, key }) => (
+			<li key={key} dir={getDir(node)}>
+				{children}
+			</li>
+		),
 		list: ({ children, key }) => <ul key={key}>{children}</ul>,
 		oList: ({ children, key }) => <ol key={key}>{children}</ol>,
 		image: ({ node, key }) => {

--- a/test/react-server/PrismicRichText.test.tsx
+++ b/test/react-server/PrismicRichText.test.tsx
@@ -69,7 +69,7 @@ it("returns <h1> if type is heading1", async () => {
 	];
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<h1>Heading 1</h1>);
+	const expected = renderJSON(<h1 dir={undefined}>Heading 1</h1>);
 
 	expect(actual).toStrictEqual(expected);
 });
@@ -84,7 +84,7 @@ it("returns <h2> if type is heading2", async () => {
 	];
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<h2>Heading 2</h2>);
+	const expected = renderJSON(<h2 dir={undefined}>Heading 2</h2>);
 
 	expect(actual).toStrictEqual(expected);
 });
@@ -99,7 +99,7 @@ it("returns <h3> if type is heading3", async () => {
 	];
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<h3>Heading 3</h3>);
+	const expected = renderJSON(<h3 dir={undefined}>Heading 3</h3>);
 
 	expect(actual).toStrictEqual(expected);
 });
@@ -114,27 +114,12 @@ it("returns <h4> if type is heading4", async () => {
 	];
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<h4>Heading 4</h4>);
+	const expected = renderJSON(<h4 dir={undefined}>Heading 4</h4>);
 
 	expect(actual).toStrictEqual(expected);
 });
 
-it("returns <h4> if type is heading3", async () => {
-	const field: prismic.RichTextField = [
-		{
-			type: prismic.RichTextNodeType.heading4,
-			text: "Heading 4",
-			spans: [],
-		},
-	];
-
-	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<h4>Heading 4</h4>);
-
-	expect(actual).toStrictEqual(expected);
-});
-
-it("returns <h5> if type is heading4", async () => {
+it("returns <h5> if type is heading5", async () => {
 	const field: prismic.RichTextField = [
 		{
 			type: prismic.RichTextNodeType.heading5,
@@ -144,7 +129,7 @@ it("returns <h5> if type is heading4", async () => {
 	];
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<h5>Heading 5</h5>);
+	const expected = renderJSON(<h5 dir={undefined}>Heading 5</h5>);
 
 	expect(actual).toStrictEqual(expected);
 });
@@ -159,7 +144,7 @@ it("returns <h6> if type is heading6", async () => {
 	];
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<h6>Heading 6</h6>);
+	const expected = renderJSON(<h6 dir={undefined}>Heading 6</h6>);
 
 	expect(actual).toStrictEqual(expected);
 });
@@ -174,7 +159,7 @@ it("returns <p /> if type is paragraph", async () => {
 	];
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
-	const expected = renderJSON(<p>Paragraph bold</p>);
+	const expected = renderJSON(<p dir={undefined}>Paragraph bold</p>);
 
 	expect(actual).toStrictEqual(expected);
 });
@@ -211,7 +196,7 @@ it("returns <strong /> if type is strong", async () => {
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
 	const expected = renderJSON(
-		<p>
+		<p dir={undefined}>
 			<strong>strong</strong>
 		</p>,
 	);
@@ -236,7 +221,7 @@ it("returns <em /> if type is em", async () => {
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
 	const expected = renderJSON(
-		<p>
+		<p dir={undefined}>
 			<em>em</em>
 		</p>,
 	);
@@ -256,7 +241,7 @@ it("returns <ul> <li> </li> </ul> if type is listItem", async () => {
 	const actual = renderJSON(<PrismicRichText field={field} />);
 	const expected = renderJSON(
 		<ul>
-			<li>listItem</li>
+			<li dir={undefined}>listItem</li>
 		</ul>,
 	);
 
@@ -275,7 +260,7 @@ it("returns <ol> <li> </li> </ol> if type is listItem", async () => {
 	const actual = renderJSON(<PrismicRichText field={field} />);
 	const expected = renderJSON(
 		<ol>
-			<li>oListItem</li>
+			<li dir={undefined}>oListItem</li>
 		</ol>,
 	);
 
@@ -451,7 +436,7 @@ it("Returns <PrismicLink /> when type is hyperlink", async () => {
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
 	const expected = renderJSON(
-		<p>
+		<p dir={undefined}>
 			<a href={data.url} rel={undefined} target={undefined}>
 				hyperlink
 			</a>
@@ -492,7 +477,7 @@ it("Returns <PrismicLink /> with internalComponent from props", async () => {
 		<PrismicRichText internalLinkComponent={Link} field={field} />,
 	);
 	const expected = renderJSON(
-		<p>
+		<p dir={undefined}>
 			<a data-href="/url" data-rel={undefined} data-target={undefined}>
 				hyperlink
 			</a>
@@ -523,7 +508,7 @@ it("returns <span /> with label className if type is label", async () => {
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
 	const expected = renderJSON(
-		<p>
+		<p dir={undefined}>
 			<span className={data.label}>label</span>
 		</p>,
 	);
@@ -542,10 +527,90 @@ it("renders line breaks as <br />", async () => {
 
 	const actual = renderJSON(<PrismicRichText field={field} />);
 	const expected = renderJSON(
-		<p>
+		<p dir={undefined}>
 			line 1<br />
 			line 2
 		</p>,
+	);
+
+	expect(actual).toStrictEqual(expected);
+});
+
+it("includes `dir` attribute on right-to-left languages", async () => {
+	const field: prismic.RichTextField = [
+		{
+			type: prismic.RichTextNodeType.heading1,
+			text: "Heading 1",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.heading2,
+			text: "Heading 2",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.heading3,
+			text: "Heading 3",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.heading4,
+			text: "Heading 4",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.heading5,
+			text: "Heading 5",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.heading6,
+			text: "Heading 6",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.paragraph,
+			text: "Paragraph",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.listItem,
+			text: "listItem",
+			spans: [],
+			direction: "rtl",
+		},
+		{
+			type: prismic.RichTextNodeType.oListItem,
+			text: "oListItem",
+			spans: [],
+			direction: "rtl",
+		},
+	];
+
+	const actual = renderJSON(<PrismicRichText field={field} />);
+	const expected = renderJSON(
+		<>
+			<h1 dir="rtl">Heading 1</h1>
+			<h2 dir="rtl">Heading 2</h2>
+			<h3 dir="rtl">Heading 3</h3>
+			<h4 dir="rtl">Heading 4</h4>
+			<h5 dir="rtl">Heading 5</h5>
+			<h6 dir="rtl">Heading 6</h6>
+			<p dir="rtl">Paragraph</p>
+			<ul>
+				<li dir="rtl">listItem</li>
+			</ul>
+			<ol>
+				<li dir="rtl">oListItem</li>
+			</ol>
+		</>,
 	);
 
 	expect(actual).toStrictEqual(expected);


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: https://prismic-team.slack.com/archives/C014VAACCQL/p1729780207755199

### Description

This PR updates the default richtext serializer to honor the `direction` property of rich text nodes and adds the appropriate `dir` attribute on right-to-left text nodes. `undefined` should serialize to "no attribute" in React according to the types.

P.S. Are we considering releasing a major of this kit to eliminate the dependency on `@prismicio/types`/`@prismicio/richtext`? It's not that much of a big deal for now but might cause more issues later on.

Related:
- `@prismicio/client` PR: https://github.com/prismicio/prismic-client/pull/357
- `@prismicio/svelte` PR: https://github.com/prismicio/prismic-svelte/pull/24

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.