### PR TITLE
feat: remove `tableComponents` prop

### DIFF
--- a/e2e-projects/nextjs/app/PrismicTable/page.tsx
+++ b/e2e-projects/nextjs/app/PrismicTable/page.tsx
@@ -28,7 +28,7 @@ export default async function Page() {
 			<div data-testid="custom-table">
 				<PrismicTable
 					field={tests.filled}
-					tableComponents={{
+					components={{
 						table: ({ children }) => <div className="table">{children}</div>,
 						thead: ({ children }) => <div className="head">{children}</div>,
 						tbody: ({ children }) => <div className="body">{children}</div>,
@@ -42,12 +42,10 @@ export default async function Page() {
 			<div data-testid="custom-cell-content">
 				<PrismicTable
 					field={tests.filled}
-					tableComponents={{
+					components={{
 						table: ({ children }) => (
 							<table className="table">{children}</table>
 						),
-					}}
-					components={{
 						paragraph: ({ children }) => (
 							<p className="paragraph">{children}</p>
 						),

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 			"devDependencies": {
 				"@eslint/js": "^9.19.0",
 				"@playwright/test": "^1.50.0",
-				"@prismicio/client": "^7.16.0",
+				"@prismicio/client": "^7.16.1",
 				"@rollup/plugin-typescript": "^12.1.2",
 				"@size-limit/preset-small-lib": "^11.1.6",
 				"@types/react": "^19.0.8",
@@ -1563,9 +1563,9 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.16.0.tgz",
-			"integrity": "sha512-oKBkkOuRYujdiUgn5fs8qAPZJzJ44FYMFwFCY1iw/ODQ1UhOFh6uUJzgcKe4TPlw1mhRvsNOlJlmW2NTZmrFFg==",
+			"version": "7.16.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.16.1.tgz",
+			"integrity": "sha512-mH3JtysZyQv47OYWzuxp8vW3uWllMBJa6HD2j4cfc7vLCoxGxMrvH6Ttw12KMnChg2/exwFdq3K1OvHAtyEVdQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"imgix-url-builder": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@eslint/js": "^9.19.0",
 		"@playwright/test": "^1.50.0",
-		"@prismicio/client": "^7.16.0",
+		"@prismicio/client": "^7.16.1",
 		"@rollup/plugin-typescript": "^12.1.2",
 		"@size-limit/preset-small-lib": "^11.1.6",
 		"@types/react": "^19.0.8",

--- a/src/PrismicTable.tsx
+++ b/src/PrismicTable.tsx
@@ -1,15 +1,16 @@
 import { ReactNode } from "react";
-import { isFilled, TableField } from "@prismicio/client";
-import { JSXMapSerializer, PrismicRichText } from "./PrismicRichText.js";
+import {
+	isFilled,
+	TableField,
+	TableFieldHead,
+	TableFieldHeadRow,
+	TableFieldBody,
+	TableFieldBodyRow,
+	TableFieldHeaderCell,
+	TableFieldDataCell,
+} from "@prismicio/client";
 
-type TableFieldHead = NonNullable<TableField<"filled">["head"]>;
-type TableFieldBody = TableField<"filled">["body"];
-type TableFieldRow =
-	| TableFieldHead["rows"][number]
-	| TableFieldBody["rows"][number];
-type TableFieldCell = TableFieldRow["cells"][number];
-type TableFieldHeaderCell = Extract<TableFieldCell, { type: "header" }>;
-type TableFieldDataCell = Extract<TableFieldCell, { type: "data" }>;
+import { JSXMapSerializer, PrismicRichText } from "./PrismicRichText.js";
 
 type TableComponents = {
 	table?: (props: {
@@ -18,7 +19,10 @@ type TableComponents = {
 	}) => ReactNode;
 	thead?: (props: { head: TableFieldHead; children: ReactNode }) => ReactNode;
 	tbody?: (props: { body: TableFieldBody; children: ReactNode }) => ReactNode;
-	tr?: (props: { row: TableFieldRow; children: ReactNode }) => ReactNode;
+	tr?: (props: {
+		row: TableFieldHeadRow | TableFieldBodyRow;
+		children: ReactNode;
+	}) => ReactNode;
 	th?: (props: {
 		cell: TableFieldHeaderCell;
 		children: ReactNode;
@@ -26,7 +30,7 @@ type TableComponents = {
 	td?: (props: { cell: TableFieldDataCell; children: ReactNode }) => ReactNode;
 };
 
-const defaultTableComponents: Required<TableComponents> = {
+const defaultComponents: Required<TableComponents> = {
 	table: ({ children }) => <table>{children}</table>,
 	thead: ({ children }) => <thead>{children}</thead>,
 	tbody: ({ children }) => <tbody>{children}</tbody>,
@@ -37,23 +41,22 @@ const defaultTableComponents: Required<TableComponents> = {
 
 export type PrismicTableProps = {
 	field: TableField;
-	components?: JSXMapSerializer;
-	tableComponents?: TableComponents;
+	components?: JSXMapSerializer & TableComponents;
 	fallback?: ReactNode;
 };
 
 export function PrismicTable(props: PrismicTableProps) {
-	const { field, components, tableComponents, fallback = null } = props;
+	const { field, components, fallback = null } = props;
 
 	if (!isFilled.table(field)) {
-		return fallback ?? null;
+		return fallback;
 	}
 
 	const {
 		table: Table,
 		thead: Thead,
 		tbody: Tbody,
-	} = { ...defaultTableComponents, ...tableComponents };
+	} = { ...defaultComponents, ...components };
 
 	return (
 		<Table table={field}>
@@ -64,7 +67,6 @@ export function PrismicTable(props: PrismicTableProps) {
 							key={JSON.stringify(row)}
 							row={row}
 							components={components}
-							tableComponents={tableComponents}
 						/>
 					))}
 				</Thead>
@@ -75,7 +77,6 @@ export function PrismicTable(props: PrismicTableProps) {
 						key={JSON.stringify(row)}
 						row={row}
 						components={components}
-						tableComponents={tableComponents}
 					/>
 				))}
 			</Tbody>
@@ -84,19 +85,14 @@ export function PrismicTable(props: PrismicTableProps) {
 }
 
 type TableRowProps = {
-	row: TableFieldRow;
-	components?: JSXMapSerializer;
-	tableComponents?: TableComponents;
+	row: TableFieldHeadRow | TableFieldBodyRow;
+	components?: JSXMapSerializer & TableComponents;
 };
 
 function TableRow(props: TableRowProps) {
-	const { row, components, tableComponents } = props;
+	const { row, components } = props;
 
-	const {
-		tr: Tr,
-		th: Th,
-		td: Td,
-	} = { ...defaultTableComponents, ...tableComponents };
+	const { tr: Tr, th: Th, td: Td } = { ...defaultComponents, ...components };
 
 	return (
 		<Tr row={row}>


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR edits #219 with the following changes:

- Uses newly exported table field types from `@prismicio/client`. See https://github.com/prismicio/prismic-client/pull/377.
- Removes the `tableComponents` prop. It was used in the example but not intended for the final API.
- Makes the assumption that function-based rich text serializers are not supported.

> [!IMPORTANT]
> The new `@prismicio/client` table types are not published yet, causing tests to fail. `@prismicio/client` should be updated once https://github.com/prismicio/prismic-client/pull/377 is merged and published.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
