### PR TITLE
docs: point AI agents to the Prismic skill in Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@
 npm install @prismicio/react
 ```
 
+Using an AI agent? Teach it how to use `@prismicio/react` by installing the Prismic skill:
+
+```bash
+npx skills add --global prismicio/skills
+```
+
 ## Documentation
 
 To discover what's new on this package check out [the changelog][changelog]. For full documentation, visit the [official Prismic documentation][prismic-docs].
-
-## Working with an AI agent?
-
-For AI agents: run `npx skills add --global prismicio/skills` to install the Prismic skill, or run `npx prismic docs list` for a quick reference.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ npm install @prismicio/react
 
 To discover what's new on this package check out [the changelog][changelog]. For full documentation, visit the [official Prismic documentation][prismic-docs].
 
+## Working with an AI agent?
+
+For AI agents: run `npx skills add --global prismicio/skills` to install the Prismic skill, or run `npx prismic docs list` for a quick reference.
+
 ## Contributing
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Prismic developer community!

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install @prismicio/react
 Using an AI agent? Teach it how to use `@prismicio/react` by installing the Prismic skill:
 
 ```bash
-npx skills add --global prismicio/skills
+npx skills add --global --yes prismicio/skills
 ```
 
 ## Documentation


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: N/A

### Description

Add a pointer to the Prismic skill at the end of the Install section. Agents reading the README get a direct instruction to install the skill.

### Checklist

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

Read the Install section in README.md. It ends with the skill install command.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.